### PR TITLE
Fix gluetun Markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ An advanced bash script to manage multiple VPN containers using Docker.
 
 ## Overview
 
-This tool simplifies the management of multiple VPN containers, each running their own proxy server using the [gluetun](https://github.com/qdm12/gluetun) image. You can create, configure, and monitor VPN proxies for different locations with minimal effort.
+This tool simplifies the management of multiple VPN containers, each running their own proxy server using the [gluetun](https://github.com/qdm12/gluetun) image.
+You can create, configure, and monitor VPN proxies for different locations with minimal effort.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- keep gluetun link on one line in README for proper Markdown rendering

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6895d1408e70832f93e7287335df18f0