### PR TITLE
Introduce ComposeManager and VPNService

### DIFF
--- a/src/proxy2vpn/__init__.py
+++ b/src/proxy2vpn/__init__.py
@@ -4,4 +4,6 @@ __all__ = [
     "cli",
     "compose_utils",
     "docker_ops",
+    "compose_manager",
+    "models",
 ]

--- a/src/proxy2vpn/compose_manager.py
+++ b/src/proxy2vpn/compose_manager.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from ruamel.yaml import YAML
+
+from .models import VPNService
+
+
+class ComposeManager:
+    """Manage docker-compose files for VPN services."""
+
+    def __init__(self, compose_path: Path) -> None:
+        self.compose_path = compose_path
+        self.yaml = YAML()
+        self.data: Dict[str, Any] = self._load()
+
+    def _load(self) -> Dict[str, Any]:
+        with self.compose_path.open("r", encoding="utf-8") as f:
+            return self.yaml.load(f)
+
+    @property
+    def config(self) -> Dict[str, Any]:
+        """Return global configuration stored under x-config."""
+        return self.data.get("x-config", {})
+
+    def list_services(self) -> List[VPNService]:
+        services = self.data.get("services", {})
+        return [VPNService.from_compose_service(name, svc) for name, svc in services.items()]
+
+    def get_service(self, name: str) -> VPNService:
+        services = self.data.get("services", {})
+        if name not in services:
+            raise KeyError(f"Service '{name}' not found")
+        return VPNService.from_compose_service(name, services[name])
+
+    def add_service(self, service: VPNService) -> None:
+        services = self.data.setdefault("services", {})
+        if service.name in services:
+            raise ValueError(f"Service '{service.name}' already exists")
+        services[service.name] = service.to_compose_service()
+        self.save()
+
+    def remove_service(self, name: str) -> None:
+        services = self.data.get("services", {})
+        if name not in services:
+            raise KeyError(f"Service '{name}' not found")
+        del services[name]
+        self.save()
+
+    def save(self) -> None:
+        with self.compose_path.open("w", encoding="utf-8") as f:
+            self.yaml.dump(self.data, f)

--- a/src/proxy2vpn/models.py
+++ b/src/proxy2vpn/models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class VPNService:
+    name: str
+    port: int
+    provider: str
+    profile: str
+    location: str
+    environment: Dict[str, str]
+    labels: Dict[str, str]
+
+    @classmethod
+    def from_compose_service(cls, name: str, service_def: Dict) -> "VPNService":
+        ports = service_def.get("ports", [])
+        host_port = 0
+        if ports:
+            mapping = str(ports[0])
+            parts = mapping.split(":")
+            if len(parts) >= 3:
+                host_port = int(parts[1])
+            elif len(parts) == 2:
+                host_port = int(parts[0])
+            else:
+                host_port = int(mapping)
+        env_list = service_def.get("environment", [])
+        env_dict: Dict[str, str] = {}
+        for item in env_list:
+            if isinstance(item, str) and "=" in item:
+                k, v = item.split("=", 1)
+                env_dict[k] = v
+        labels = dict(service_def.get("labels", {}))
+        provider = labels.get("vpn.provider", env_dict.get("VPN_SERVICE_PROVIDER", ""))
+        profile = labels.get("vpn.profile", "")
+        location = labels.get("vpn.location", env_dict.get("SERVER_CITIES", ""))
+        return cls(
+            name=name,
+            port=host_port,
+            provider=provider,
+            profile=profile,
+            location=location,
+            environment=env_dict,
+            labels=labels,
+        )
+
+    def to_compose_service(self) -> Dict:
+        env_list = [f"{k}={v}" for k, v in self.environment.items()]
+        service = {
+            "ports": [f"{self.port}:8888/tcp"],
+            "environment": env_list,
+            "labels": self.labels,
+        }
+        return service

--- a/tests/test_compose.yml
+++ b/tests/test_compose.yml
@@ -1,3 +1,8 @@
+
+x-config:
+  health_check_interval: "5"
+  auto_restart: "true"
+
 x-vpn-base-test: &vpn-base-test
   image: qmcgaw/gluetun
   cap_add:

--- a/tests/test_compose_manager.py
+++ b/tests/test_compose_manager.py
@@ -1,0 +1,51 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn.compose_manager import ComposeManager
+from proxy2vpn.models import VPNService
+
+
+def _copy_compose(tmp_path):
+    compose_src = pathlib.Path(__file__).parent / "test_compose.yml"
+    compose_path = tmp_path / "docker-compose.yml"
+    compose_path.write_text(compose_src.read_text())
+    return compose_path
+
+
+def test_read_config_and_services(tmp_path):
+    compose_path = _copy_compose(tmp_path)
+    manager = ComposeManager(compose_path)
+    assert manager.config["health_check_interval"] == "5"
+    services = manager.list_services()
+    assert {s.name for s in services} == {"testvpn1", "testvpn2"}
+
+
+def test_add_and_remove_service(tmp_path):
+    compose_path = _copy_compose(tmp_path)
+    manager = ComposeManager(compose_path)
+    new_service = VPNService(
+        name="vpn3",
+        port=7777,
+        provider="protonvpn",
+        profile="test",
+        location="LA",
+        environment={
+            "VPN_SERVICE_PROVIDER": "protonvpn",
+            "SERVER_CITIES": "LA",
+        },
+        labels={
+            "vpn.type": "vpn",
+            "vpn.port": "8888",
+            "vpn.provider": "protonvpn",
+            "vpn.profile": "test",
+            "vpn.location": "LA",
+        },
+    )
+    manager.add_service(new_service)
+    assert "vpn3" in {s.name for s in manager.list_services()}
+    # ensure existing service anchor remains in file
+    assert "<<: *vpn-base-test" in compose_path.read_text()
+    manager.remove_service("vpn3")
+    assert "vpn3" not in {s.name for s in manager.list_services()}


### PR DESCRIPTION
## Summary
- manage compose.yml files via new ComposeManager
- define VPNService dataclass to translate compose services
- cover compose operations with tests and include global config in test compose file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895efeb1e78832fbde8361b16a8a5cd