### PR TITLE
feat: manage compose profiles via CLI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,32 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/python-tests.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.py'
+      - 'pyproject.toml'
+      - '.github/workflows/python-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.commits[0].message, '[skip tests]') }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.11'
+
+      - name: Run tests
+        run: uv run --with pytest pytest

--- a/src/proxy2vpn/__init__.py
+++ b/src/proxy2vpn/__init__.py
@@ -6,4 +6,6 @@ __all__ = [
     "docker_ops",
     "compose_manager",
     "models",
+    "config",
+    "server_manager",
 ]

--- a/src/proxy2vpn/compose_manager.py
+++ b/src/proxy2vpn/compose_manager.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
 
-from .models import VPNService
+from .models import Profile, VPNService
 
 
 class ComposeManager:
@@ -39,7 +40,13 @@ class ComposeManager:
         services = self.data.setdefault("services", {})
         if service.name in services:
             raise ValueError(f"Service '{service.name}' already exists")
-        services[service.name] = service.to_compose_service()
+        profile_key = f"x-vpn-base-{service.profile}"
+        profile_map = self.data.get(profile_key)
+        if profile_map is None:
+            raise KeyError(f"Profile '{service.profile}' not found")
+        svc_map = CommentedMap(service.to_compose_service())
+        svc_map.merge_attrib = [profile_map]
+        services[service.name] = svc_map
         self.save()
 
     def remove_service(self, name: str) -> None:
@@ -48,6 +55,58 @@ class ComposeManager:
             raise KeyError(f"Service '{name}' not found")
         del services[name]
         self.save()
+
+    # ------------------------------------------------------------------
+    # Profile management
+    # ------------------------------------------------------------------
+
+    def list_profiles(self) -> List[Profile]:
+        profiles: List[Profile] = []
+        for key, value in self.data.items():
+            if key.startswith("x-vpn-base-"):
+                name = key[len("x-vpn-base-") :]
+                profiles.append(Profile.from_anchor(name, value))
+        return profiles
+
+    def get_profile(self, name: str) -> Profile:
+        key = f"x-vpn-base-{name}"
+        if key not in self.data:
+            raise KeyError(f"Profile '{name}' not found")
+        return Profile.from_anchor(name, self.data[key])
+
+    def add_profile(self, profile: Profile) -> None:
+        key = f"x-vpn-base-{profile.name}"
+        if key in self.data:
+            raise ValueError(f"Profile '{profile.name}' already exists")
+        anchor_map = CommentedMap(profile.to_anchor())
+        anchor_map.yaml_set_anchor(f"vpn-base-{profile.name}", always_dump=True)
+        self.data[key] = anchor_map
+        self.save()
+
+    def remove_profile(self, name: str) -> None:
+        key = f"x-vpn-base-{name}"
+        if key not in self.data:
+            raise KeyError(f"Profile '{name}' not found")
+        del self.data[key]
+        self.save()
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+
+    def next_available_port(self, start: int = 0) -> int:
+        """Find the next available host port starting from START.
+
+        If START is 0 the search begins from 20000 which is the default
+        range used by proxy2vpn.  Existing service ports are inspected and
+        the first free port is returned.
+        """
+
+        port = start or 20000
+        used = {svc.port for svc in self.list_services()}
+        while port in used:
+            port += 1
+        return port
 
     def save(self) -> None:
         with self.compose_path.open("w", encoding="utf-8") as f:

--- a/src/proxy2vpn/config.py
+++ b/src/proxy2vpn/config.py
@@ -1,0 +1,35 @@
+"""Default configuration for proxy2vpn.
+
+This module centralizes paths and default values used across the
+application.  All state is stored in the docker compose file referenced
+by :data:`COMPOSE_FILE`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+# Path to the docker compose file that acts as the single source of truth
+# for all proxy2vpn state.  The path is relative to the current working
+# directory of the CLI unless an absolute path is provided by the user.
+COMPOSE_FILE: Path = Path("compose.yml")
+
+# Directory used to cache data such as the downloaded server lists.  The
+# cache location defaults to ``~/.cache/proxy2vpn`` which follows the
+# XDG base directory specification on Linux systems.
+CACHE_DIR: Path = Path.home() / ".cache" / "proxy2vpn"
+
+# Default VPN provider used when creating new services if none is
+# explicitly specified by the user.
+DEFAULT_PROVIDER = "protonvpn"
+
+# Starting port used when automatically allocating ports for new VPN
+# services.  The manager will search for the next free port starting from
+# this value.
+DEFAULT_PORT_START = 20000
+
+# URL of the gluetun server list JSON file.  This file is fetched and
+# cached by :class:`ServerManager` to provide location validation and
+# listing of available servers.
+SERVER_LIST_URL = (
+    "https://raw.githubusercontent.com/qdm12/gluetun/master/internal/storage/servers.json"
+)

--- a/src/proxy2vpn/server_manager.py
+++ b/src/proxy2vpn/server_manager.py
@@ -1,0 +1,61 @@
+"""Utilities for fetching and caching VPN server lists."""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import requests
+
+from . import config
+
+
+class ServerManager:
+    """Manage gluetun server list information.
+
+    The server list is downloaded from GitHub and cached locally to avoid
+    repeated network requests.  The cache is considered valid for ``ttl``
+    seconds (24h by default).
+    """
+
+    def __init__(self, cache_dir: Path | None = None, ttl: int = 24 * 3600) -> None:
+        self.cache_dir = cache_dir or config.CACHE_DIR
+        self.cache_file = self.cache_dir / "servers.json"
+        self.ttl = ttl
+        self.data: Dict[str, Dict] | None = None
+
+    # ------------------------------------------------------------------
+    # Fetching and caching
+    # ------------------------------------------------------------------
+
+    def _is_cache_valid(self) -> bool:
+        if not self.cache_file.exists():
+            return False
+        age = time.time() - self.cache_file.stat().st_mtime
+        return age < self.ttl
+
+    def update_servers(self) -> Dict[str, Dict]:
+        """Fetch the server list, using the cache when possible."""
+
+        if not self._is_cache_valid():
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            response = requests.get(config.SERVER_LIST_URL, timeout=30)
+            response.raise_for_status()
+            self.cache_file.write_text(response.text, encoding="utf-8")
+        with self.cache_file.open("r", encoding="utf-8") as f:
+            self.data = json.load(f)
+        return self.data
+
+    # ------------------------------------------------------------------
+    # Listing helpers
+    # ------------------------------------------------------------------
+
+    def list_providers(self) -> List[str]:
+        data = self.data or self.update_servers()
+        return sorted(data.keys())
+
+    def list_countries(self, provider: str) -> List[str]:
+        data = self.data or self.update_servers()
+        prov = data.get(provider, {})
+        return sorted(prov.keys())


### PR DESCRIPTION
## Summary
- manage VPN profiles as YAML anchors in compose.yml
- add config module, server list caching, and Typer-based CLI for profile and service ops
- provide utility to allocate ports and manipulate compose services
- merge latest main to include Python tests CI workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689606d4357c832f9359c9c6f3c75778