### PR TITLE
Handle SSL failures when updating server list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typer",
     "ruamel.yaml",
     "docker",
+    "requests",
 ]
 
 [project.scripts]

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -119,11 +119,18 @@ def vpn_delete(name: str):
 
 
 @server_app.command("update")
-def servers_update():
+def servers_update(
+    insecure: bool = typer.Option(
+        False,
+        "--insecure",
+        help="Disable SSL certificate verification (for troubleshooting)",
+    ),
+):
     """Download and cache the latest server list."""
 
     mgr = ServerManager()
-    mgr.update_servers()
+    verify = not insecure
+    mgr.update_servers(verify=verify)
     typer.echo("Server list updated.")
 
 

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -1,0 +1,38 @@
+import pytest
+import requests
+import typer
+
+from proxy2vpn.server_manager import ServerManager
+
+
+def test_update_servers_ssl_error(tmp_path, monkeypatch):
+    mgr = ServerManager(cache_dir=tmp_path)
+
+    def fake_get(*args, **kwargs):
+        raise requests.exceptions.SSLError("bad ssl")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        mgr.update_servers()
+    assert excinfo.value.exit_code == 1
+
+
+def test_update_servers_insecure_flag(tmp_path, monkeypatch):
+    called = {}
+
+    class Resp:
+        text = "{}"
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout, verify):
+        called["verify"] = verify
+        return Resp()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    mgr = ServerManager(cache_dir=tmp_path)
+    mgr.update_servers(verify=False)
+    assert called["verify"] is False


### PR DESCRIPTION
## Summary
- Catch SSL errors when downloading VPN server list and provide helpful message
- Add `--insecure` flag to `servers update` command to disable certificate verification
- Include requests as a project dependency and add tests for new behaviors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896fd2180e8832fb9e74320a4b6365f