### PR TITLE
Add VPN test, location helpers, and preset utilities

### DIFF
--- a/src/proxy2vpn/preset_manager.py
+++ b/src/proxy2vpn/preset_manager.py
@@ -1,0 +1,47 @@
+"""Preset utilities built on top of YAML anchors."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from . import config
+from .compose_manager import ComposeManager
+from .models import VPNService
+
+
+def list_available_presets(compose_file: Path | None = None) -> List[str]:
+    """Return names of available presets (profile anchors)."""
+
+    mgr = ComposeManager(compose_file or config.COMPOSE_FILE)
+    return [profile.name for profile in mgr.list_profiles()]
+
+
+def apply_preset(
+    preset_name: str,
+    service_name: str,
+    port: int,
+    compose_file: Path | None = None,
+) -> None:
+    """Create a VPN service using a preset anchor."""
+
+    mgr = ComposeManager(compose_file or config.COMPOSE_FILE)
+    # Ensure preset exists
+    mgr.get_profile(preset_name)
+    env = {"VPN_SERVICE_PROVIDER": config.DEFAULT_PROVIDER}
+    labels = {
+        "vpn.type": "vpn",
+        "vpn.port": str(port),
+        "vpn.provider": config.DEFAULT_PROVIDER,
+        "vpn.profile": preset_name,
+        "vpn.location": "",
+    }
+    service = VPNService(
+        name=service_name,
+        port=port,
+        provider=config.DEFAULT_PROVIDER,
+        profile=preset_name,
+        location="",
+        environment=env,
+        labels=labels,
+    )
+    mgr.add_service(service)

--- a/src/proxy2vpn/server_manager.py
+++ b/src/proxy2vpn/server_manager.py
@@ -70,9 +70,38 @@ class ServerManager:
 
     def list_providers(self) -> List[str]:
         data = self.data or self.update_servers()
-        return sorted(data.keys())
+        return sorted(k for k in data.keys() if k != "version")
 
     def list_countries(self, provider: str) -> List[str]:
+        """Return available countries for PROVIDER."""
+
         data = self.data or self.update_servers()
         prov = data.get(provider, {})
-        return sorted(prov.keys())
+        servers = prov.get("servers", [])
+        countries = {srv.get("country") for srv in servers if srv.get("country")}
+        return sorted(countries)
+
+    def list_cities(self, provider: str, country: str) -> List[str]:
+        """Return available cities for PROVIDER in COUNTRY."""
+
+        data = self.data or self.update_servers()
+        prov = data.get(provider, {})
+        servers = prov.get("servers", [])
+        cities = {
+            srv.get("city")
+            for srv in servers
+            if srv.get("country") == country and srv.get("city")
+        }
+        return sorted(cities)
+
+    def validate_location(self, provider: str, location: str) -> bool:
+        """Return ``True`` if LOCATION exists for PROVIDER."""
+
+        data = self.data or self.update_servers()
+        prov = data.get(provider, {})
+        servers = prov.get("servers", [])
+        loc = location.lower()
+        for srv in servers:
+            if srv.get("city", "").lower() == loc or srv.get("country", "").lower() == loc:
+                return True
+        return False

--- a/tests/test_preset_manager.py
+++ b/tests/test_preset_manager.py
@@ -1,0 +1,21 @@
+import pathlib
+
+from proxy2vpn.preset_manager import apply_preset, list_available_presets
+from proxy2vpn.compose_manager import ComposeManager
+
+
+def _copy_compose(tmp_path: pathlib.Path) -> pathlib.Path:
+    src = pathlib.Path(__file__).parent / "test_compose.yml"
+    dest = tmp_path / "compose.yml"
+    dest.write_text(src.read_text())
+    return dest
+
+
+def test_preset_operations(tmp_path):
+    compose_path = _copy_compose(tmp_path)
+    presets = list_available_presets(compose_path)
+    assert "test" in presets
+    apply_preset("test", "vpn3", 7777, compose_path)
+    manager = ComposeManager(compose_path)
+    services = {s.name for s in manager.list_services()}
+    assert "vpn3" in services

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -36,3 +36,20 @@ def test_update_servers_insecure_flag(tmp_path, monkeypatch):
     mgr = ServerManager(cache_dir=tmp_path)
     mgr.update_servers(verify=False)
     assert called["verify"] is False
+
+
+def test_location_helpers():
+    mgr = ServerManager()
+    mgr.data = {
+        "prov": {
+            "servers": [
+                {"country": "US", "city": "New York"},
+                {"country": "US", "city": "Los Angeles"},
+                {"country": "CA", "city": "Toronto"},
+            ]
+        }
+    }
+    assert mgr.list_countries("prov") == ["CA", "US"]
+    assert mgr.list_cities("prov", "US") == ["Los Angeles", "New York"]
+    assert mgr.validate_location("prov", "Toronto")
+    assert not mgr.validate_location("prov", "Paris")


### PR DESCRIPTION
## Summary
- add VPN proxy connectivity test comparing direct and proxied IPs
- expose country/city listing and location validation helpers
- implement simple preset list/apply helpers and CLI commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68987825c76c832f88cb1291966fc393