### PR TITLE
chore: integrate towncrier changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Proxy2VPN will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Initial Python CLI (`proxy2vpn.cli`) for managing VPN containers.
+- Configuration loader and models.
+- Docker operations module with typed helpers.
+
+### Changed
+- N/A
+
+### Fixed
+- N/A
+
+<!-- towncrier release notes start -->
+
 ## [0.1.2] - 2025-05-20
 
 ### Added

--- a/news/README.md
+++ b/news/README.md
@@ -1,0 +1,2 @@
+This directory collects news fragments for towncrier.
+Add files named like <pr-number>.<type>.md with a short description of the change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,14 @@ dependencies = [
     "requests",
 ]
 
+[project.optional-dependencies]
+dev = ["towncrier"]
+
+[tool.towncrier]
+package = "proxy2vpn"
+filename = "CHANGELOG.md"
+directory = "news"
+
 [project.scripts]
 proxy2vpn = "proxy2vpn.cli:app"
 


### PR DESCRIPTION
## Summary
- configure towncrier for Python changelog generation
- seed Unreleased section for upcoming Python release
- add news fragment directory for future entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a0e37b794832fb35197586148e03e