### PR TITLE
fix: enable module execution

### DIFF
--- a/news/000.bugfix.md
+++ b/news/000.bugfix.md
@@ -1,0 +1,1 @@
+Fix module execution by providing a __main__ entry point.

--- a/src/proxy2vpn/__main__.py
+++ b/src/proxy2vpn/__main__.py
@@ -1,0 +1,12 @@
+"""Module entry point for proxy2vpn CLI."""
+
+from .cli import app
+
+
+def main() -> None:
+    """Run the proxy2vpn CLI."""
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,18 @@
+import os
+import pathlib
+import subprocess
+import sys
+
+
+def test_module_entrypoint():
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    result = subprocess.run(
+        [sys.executable, "-m", "proxy2vpn", "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "proxy2vpn command line interface" in result.stdout


### PR DESCRIPTION
## Summary
- add `__main__` module to expose CLI when running `python -m proxy2vpn`
- test module entry point
- add bugfix changelog fragment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a20322330832f8171bd8706fca871