### PR TITLE
fix: update license metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Serhii Khalymon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/news/9999.bugfix.md
+++ b/news/9999.bugfix.md
@@ -1,0 +1,2 @@
+Replace deprecated license metadata and remove outdated classifier.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ version = "0.1.3"
 description = "Proxy2VPN Python utilities"
 authors = [{ name = "Serhii Khalymon", email = "serhii.khalymon@pm.me" }]
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 keywords = ["vpn", "proxy", "utilities"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary
- replace deprecated license table with SPDX string and remove deprecated classifier
- add standalone MIT license file
- document change in news fragment

## Testing
- `pytest`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_689a206210a4832f9502c63bdde11eaa