### PR TITLE
Refactor CLI command structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,17 +33,17 @@ uv run proxy2vpn profile create myprofile profiles/myprofile.env
 uv run proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn
 uv run proxy2vpn vpn start vpn1
 uv run proxy2vpn vpn list --diagnose
-uv run proxy2vpn bulk up
+uv run proxy2vpn vpn start --all
 uv run proxy2vpn servers list-providers
-uv run proxy2vpn test vpn1
-uv run proxy2vpn diagnose --verbose
+uv run proxy2vpn vpn test vpn1
+uv run proxy2vpn system diagnose --verbose
 ```
 
 ## High-Level Architecture
 
 ### Application Organization
 The Python application (`src/proxy2vpn/`) is modular with these components:
-1. **cli.py**: Main CLI interface using Typer with command groups (profile, vpn, servers, bulk, preset, diagnose)
+1. **cli.py**: Main CLI interface using Typer with command groups (profile, vpn, servers, system, preset)
 2. **config.py**: Configuration constants and defaults (compose file paths, cache dir, default provider)
 3. **models.py**: Data models for VPNService and Profile with compose file serialization
 4. **compose_manager.py**: Docker Compose file management using ruamel.yaml for profiles and services
@@ -110,7 +110,7 @@ ServerManager class handles:
 Containers are managed through:
 - Docker Compose YAML files with YAML anchors for profiles
 - Automatic port allocation starting from 20000
-- Container labeling with `vpn.type=vpn` for bulk operations
+- Container labeling with `vpn.type=vpn` for multi-service operations
 - Profile-based configuration using environment file references
 
 ## Development Guidelines

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Python command-line interface for managing multiple VPN containers with Docker.
 ## Features
 - Manage VPN credentials as reusable profiles
 - Create and control VPN services
-- Bulk start/stop operations
+- Multi-service control with `--all` flags
 - Query and validate provider server locations
 - Apply predefined presets for common setups
 
@@ -41,7 +41,7 @@ proxy2vpn --help
 ## Quick Start
 1. Initialize the compose file:
    ```bash
-   proxy2vpn init
+   proxy2vpn system init
    ```
 
 2. Create a profile file with your VPN credentials:
@@ -67,13 +67,15 @@ proxy2vpn --help
 5. View status and test connectivity:
    ```bash
    proxy2vpn vpn list
-   proxy2vpn test vpn1
+   proxy2vpn vpn test vpn1
    ```
 
 ## Command overview
 
-### Initialization
-- `proxy2vpn init [--force]`
+### System operations
+- `proxy2vpn system init [--force]`
+- `proxy2vpn system validate`
+- `proxy2vpn system diagnose [--lines N] [--all] [--verbose] [--json]`
 
 ### Profiles
 - `proxy2vpn profile create NAME ENV_FILE`
@@ -82,18 +84,13 @@ proxy2vpn --help
 
 ### VPN services
 - `proxy2vpn vpn create NAME PROFILE [--port PORT] [--provider PROVIDER] [--location LOCATION]`
-- `proxy2vpn vpn list [--diagnose]`
-- `proxy2vpn vpn start NAME`
-- `proxy2vpn vpn stop NAME`
-- `proxy2vpn vpn restart NAME`
+- `proxy2vpn vpn list [--diagnose] [--ips-only]`
+- `proxy2vpn vpn start [NAME | --all]`
+- `proxy2vpn vpn stop [NAME | --all]`
+- `proxy2vpn vpn restart [NAME | --all]`
 - `proxy2vpn vpn logs NAME [--lines N] [--follow]`
-- `proxy2vpn vpn delete NAME`
-
-### Bulk operations
-- `proxy2vpn bulk up`
-- `proxy2vpn bulk down`
-- `proxy2vpn bulk status`
-- `proxy2vpn bulk ips`
+- `proxy2vpn vpn delete [NAME | --all]`
+- `proxy2vpn vpn test NAME`
 
 ### Server database
 - `proxy2vpn servers update`
@@ -105,10 +102,6 @@ proxy2vpn --help
 ### Presets
 - `proxy2vpn preset list`
 - `proxy2vpn preset apply PRESET SERVICE [--port PORT]`
-
-### Testing & Diagnostics
-- `proxy2vpn test SERVICE` – verify that a proxy container is reachable
-- `proxy2vpn diagnose [--all] [--lines N] [--verbose] [--json]` – analyze container health and logs
 
 ## Development
 

--- a/news/002.feature.md
+++ b/news/002.feature.md
@@ -1,0 +1,1 @@
+CLI restructure adds `system` command group, `--all` VPN flags, and deprecates `bulk` commands.

--- a/src/proxy2vpn/typer_ext.py
+++ b/src/proxy2vpn/typer_ext.py
@@ -329,11 +329,11 @@ class HelpfulTyper(typer.Typer):
                 f"{command_path} list-providers",
                 f"{command_path} list-countries nordvpn",
             ]
-        elif "bulk" in command_path:
+        elif "system" in command_path:
             examples = [
-                f"{command_path} up",
-                f"{command_path} down",
-                f"{command_path} status",
+                f"{command_path} init",
+                f"{command_path} validate",
+                f"{command_path} diagnose",
             ]
         elif "preset" in command_path:
             examples = [
@@ -355,7 +355,7 @@ class HelpfulTyper(typer.Typer):
             "vpn": f"{base_url}#vpn-management",
             "profile": f"{base_url}#profile-management",
             "servers": f"{base_url}#server-lists",
-            "bulk": f"{base_url}#bulk-operations",
+            "system": f"{base_url}#system-operations",
             "preset": f"{base_url}#presets",
         }
 

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -20,7 +20,7 @@ def _run_proxy2vpn(args, cwd):
 
 
 def test_init_creates_compose(tmp_path):
-    result = _run_proxy2vpn(["init"], tmp_path)
+    result = _run_proxy2vpn(["system", "init"], tmp_path)
     assert result.returncode == 0
     compose = tmp_path / "compose.yml"
     assert compose.exists()
@@ -34,8 +34,8 @@ def test_init_requires_force(tmp_path):
     compose = tmp_path / "compose.yml"
     compose.write_text("services: {}\n")
 
-    result = _run_proxy2vpn(["init"], tmp_path)
+    result = _run_proxy2vpn(["system", "init"], tmp_path)
     assert result.returncode != 0
 
-    result = _run_proxy2vpn(["init", "--force"], tmp_path)
+    result = _run_proxy2vpn(["system", "init", "--force"], tmp_path)
     assert result.returncode == 0


### PR DESCRIPTION
## Summary
- add `system` command group for init, validate, and diagnose operations
- support `--all` flag across VPN start/stop/restart/delete and add `--ips-only` to `vpn list`
- move `test` under `vpn` group and deprecate old `bulk` commands

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689a498a8348832f80f63959cde5d72d