### PR TITLE
fix: show help for empty commands

### DIFF
--- a/news/123.bugfix.md
+++ b/news/123.bugfix.md
@@ -1,0 +1,1 @@
+Show help when running the CLI without arguments and display a message for missing required arguments.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -56,6 +56,10 @@ def main(
     ctx.obj = ctx.obj or {}
     ctx.obj["compose_file"] = compose_file
 
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
+
 
 # ---------------------------------------------------------------------------
 # System commands

--- a/src/proxy2vpn/typer_ext.py
+++ b/src/proxy2vpn/typer_ext.py
@@ -50,7 +50,7 @@ class HelpfulTyper(typer.Typer):
             self._show_no_such_command_help(exc)
         else:
             # For other errors, format them nicely
-            error_msg = exc.message.strip()
+            error_msg = (getattr(exc, "message", "") or str(exc)).strip()
 
             # Handle missing argument errors
             if "Missing argument" in error_msg:

--- a/tests/test_cli_empty_commands.py
+++ b/tests/test_cli_empty_commands.py
@@ -1,0 +1,29 @@
+import os
+import pathlib
+import subprocess
+import sys
+
+repo_root = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "src")
+    return subprocess.run(
+        [sys.executable, "-m", "proxy2vpn", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_root_command_shows_help():
+    result = _run_cli()
+    assert result.returncode == 0
+    assert "proxy2vpn command line interface" in result.stdout
+
+
+def test_missing_arguments_show_error():
+    result = _run_cli("profile", "create")
+    assert result.returncode == 2
+    assert "Missing parameter" in result.stderr


### PR DESCRIPTION
## Summary
- display help when running `proxy2vpn` without arguments
- show message for missing required parameters
- test empty command behaviour

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689a5f4e8af4832fa856786fa25d3189