### PR TITLE
feat: harden CLI with input validation and error handling

### DIFF
--- a/news/input-validation.feature.md
+++ b/news/input-validation.feature.md
@@ -1,0 +1,1 @@
+Enhance CLI safety with standardized error handling, input validation, and destructive operation prompts.

--- a/src/proxy2vpn/utils.py
+++ b/src/proxy2vpn/utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import typer
+
+
+def abort(message: str, suggestion: str | None = None, code: int = 1) -> None:
+    """Print a standardized error message and exit."""
+    typer.echo(f"Error: {message}", err=True)
+    if suggestion:
+        typer.echo(f"Hint: {suggestion}", err=True)
+    raise typer.Exit(code)

--- a/src/proxy2vpn/validators.py
+++ b/src/proxy2vpn/validators.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import typer
+
+# Allowed characters for user provided names (profiles, services, etc.)
+_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def sanitize_name(value: str) -> str:
+    """Trim and validate NAME-like parameters."""
+    cleaned = value.strip()
+    if not _NAME_RE.match(cleaned):
+        raise typer.BadParameter("Use alphanumeric characters, '-' or '_' only")
+    return cleaned
+
+
+def validate_port(port: int) -> int:
+    """Ensure PORT is within valid bounds."""
+    if not 0 <= port <= 65535:
+        raise typer.BadParameter("Port must be between 0 and 65535")
+    return port
+
+
+def sanitize_path(path: Path) -> Path:
+    """Resolve and return PATH with user expansion."""
+    return path.expanduser().resolve()

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -23,11 +23,15 @@ def test_update_servers_insecure_flag(tmp_path, monkeypatch):
 
     class Resp:
         text = "{}"
+        headers = {"content-length": "2"}
 
         def raise_for_status(self):
             pass
 
-    def fake_get(url, timeout, verify):
+        def iter_content(self, chunk_size: int):
+            yield b"{}"
+
+    def fake_get(url, timeout, verify, stream=False):
         called["verify"] = verify
         return Resp()
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import pytest
+import typer
+
+from proxy2vpn.validators import sanitize_name, sanitize_path, validate_port
+
+
+def test_validate_port_bounds():
+    assert validate_port(8080) == 8080
+    with pytest.raises(typer.BadParameter):
+        validate_port(70000)
+
+
+def test_sanitize_name():
+    assert sanitize_name("good-name") == "good-name"
+    with pytest.raises(typer.BadParameter):
+        sanitize_name("bad name!")
+
+
+def test_sanitize_path(tmp_path):
+    p = tmp_path / "file"
+    resolved = sanitize_path(Path(str(p)))
+    assert resolved.is_absolute()


### PR DESCRIPTION
## Summary
- add reusable validators and abort utility for consistent CLI errors
- confirm destructive actions and validate user input across commands
- show progress bars for server updates and diagnostics

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b23d7396c832fa281abb505e9f9ac