### PR TITLE
feat: add force flag to vpn start command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 *.egg-info/
 .codana/
+.dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ uv run proxy2vpn <command> [args]
 uv run proxy2vpn profile create myprofile profiles/myprofile.env
 uv run proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn
 uv run proxy2vpn vpn start vpn1
+uv run proxy2vpn vpn start --force vpn1
 uv run proxy2vpn vpn list --diagnose
 uv run proxy2vpn vpn start --all
 uv run proxy2vpn servers list-providers

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ proxy2vpn --help
    ```bash
    proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn --location "New York"
    proxy2vpn vpn start vpn1
+   # Use --force to recreate the container if it already exists
+   # proxy2vpn vpn start --force vpn1
    ```
 
 5. View status and test connectivity:
@@ -85,7 +87,7 @@ proxy2vpn --help
 ### VPN services
 - `proxy2vpn vpn create NAME PROFILE [--port PORT] [--provider PROVIDER] [--location LOCATION]`
 - `proxy2vpn vpn list [--diagnose] [--ips-only]`
-- `proxy2vpn vpn start [NAME | --all]`
+- `proxy2vpn vpn start [NAME | --all] [--force]`
 - `proxy2vpn vpn stop [NAME | --all]`
 - `proxy2vpn vpn restart [NAME | --all]`
 - `proxy2vpn vpn logs NAME [--lines N] [--follow]`

--- a/news/force-start.feature.md
+++ b/news/force-start.feature.md
@@ -1,0 +1,1 @@
+Add --force flag to `vpn start` to recreate containers instead of starting existing ones.

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -70,13 +70,17 @@ def create_container(
 
 
 def _load_env_file(path: str) -> dict[str, str]:
-    """Return environment variables loaded from PATH."""
+    """Return environment variables loaded from PATH.
+
+    If PATH is empty, does not exist, or is not a regular file, return an empty dict.
+    """
 
     env: dict[str, str] = {}
     if not path:
         return env
     file_path = Path(path)
-    if not file_path.exists():
+    # Only proceed if it's a regular file; ignore directories or non-existing paths
+    if not file_path.is_file():
         return env
     for line in file_path.read_text().splitlines():
         line = line.strip()


### PR DESCRIPTION
## Summary
- add `--force` option to `vpn start` for container recreation
- support forced recreation in Docker operations with `recreate_vpn_container`
- document new flag and cover with tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689b2b4d5044832f9def41d9c7dc51c2