### PR TITLE
feat: update server list during system init

### DIFF
--- a/news/0001.feature.md
+++ b/news/0001.feature.md
@@ -1,0 +1,2 @@
+Add server list update when running `system init`.
+

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -98,7 +98,9 @@ def system_init(
             f"Compose file '{compose_file}' already exists",
             "Use --force to overwrite",
         )
-    typer.echo(f"Created '{compose_file}'.")
+    mgr = ServerManager()
+    mgr.update_servers()
+    typer.echo(f"Created '{compose_file}' and updated server list.")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -4,6 +4,10 @@ import subprocess
 import sys
 
 from ruamel.yaml import YAML
+from types import SimpleNamespace
+
+from proxy2vpn.cli import system_init
+from proxy2vpn.server_manager import ServerManager
 
 
 def _run_proxy2vpn(args, cwd):
@@ -39,3 +43,15 @@ def test_init_requires_force(tmp_path):
 
     result = _run_proxy2vpn(["system", "init", "--force"], tmp_path)
     assert result.returncode == 0
+
+
+def test_system_init_updates_servers(tmp_path, monkeypatch):
+    called = {}
+
+    def fake_update(self, verify=True):
+        called["update"] = verify
+
+    monkeypatch.setattr(ServerManager, "update_servers", fake_update)
+    ctx = SimpleNamespace(obj={"compose_file": tmp_path / "compose.yml"})
+    system_init(ctx, force=True)
+    assert called["update"] is True


### PR DESCRIPTION
## Summary
- refresh cached server list automatically when running `system init`
- test `system init` updates server list
- document change in changelog fragment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b38807a24832fb5bac6c736c46754