### PR TITLE
fix: add profile anchors to compose services

### DIFF
--- a/news/145.bugfix.md
+++ b/news/145.bugfix.md
@@ -1,0 +1,1 @@
+Fix generated compose files to drop the deprecated `version` key and merge VPN services with their profiles via `<<: *vpn-base-<profile>`.

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -28,6 +28,7 @@ def test_init_creates_compose(tmp_path):
     data = yaml.load(compose.read_text())
     assert data["services"] == {}
     assert "proxy2vpn_network" in data["networks"]
+    assert "version" not in data
 
 
 def test_init_requires_force(tmp_path):


### PR DESCRIPTION
## Summary
- drop deprecated version key from initial compose template
- merge VPN services with their profile anchors in compose.yml
- test compose init and profile merge

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b390ec940832f93377f3287f21380