### PR TITLE
feat: support forced VPN restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ proxy2vpn --help
 - `proxy2vpn vpn list [--diagnose] [--ips-only]`
 - `proxy2vpn vpn start [NAME | --all] [--force]`
 - `proxy2vpn vpn stop [NAME | --all]`
-- `proxy2vpn vpn restart [NAME | --all]`
+- `proxy2vpn vpn restart [NAME | --all] [--force]`
 - `proxy2vpn vpn logs NAME [--lines N] [--follow]`
 - `proxy2vpn vpn delete [NAME | --all]`
 - `proxy2vpn vpn test NAME`

--- a/news/001.feature.md
+++ b/news/001.feature.md
@@ -1,0 +1,1 @@
+feat: allow `vpn restart --all --force` to recreate containers

--- a/tests/test_vpn_restart_force.py
+++ b/tests/test_vpn_restart_force.py
@@ -1,0 +1,40 @@
+import pathlib
+import sys
+from types import SimpleNamespace
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from typer.testing import CliRunner
+
+from proxy2vpn import cli, docker_ops
+
+
+def test_vpn_restart_all_force(monkeypatch):
+    runner = CliRunner()
+
+    dummy_mgr = SimpleNamespace(
+        list_services=lambda: [SimpleNamespace(name="svc1", profile="prof1")],
+        get_profile=lambda name: SimpleNamespace(
+            env_file="env", image="img", cap_add=[], devices=[]
+        ),
+        get_service=lambda name: SimpleNamespace(name=name, profile="prof1"),
+    )
+
+    monkeypatch.setattr(cli, "ComposeManager", lambda path: dummy_mgr)
+
+    calls = []
+
+    def fake_recreate(service, profile):
+        calls.append(("recreate", service.name))
+
+    def fake_start(name):
+        calls.append(("start", name))
+
+    monkeypatch.setattr(docker_ops, "recreate_vpn_container", fake_recreate)
+    monkeypatch.setattr(docker_ops, "start_container", fake_start)
+
+    result = runner.invoke(cli.app, ["vpn", "restart", "--all", "--force"])
+    assert result.exit_code == 0
+    assert "Recreated and restarted svc1" in result.stdout
+    assert ("recreate", "svc1") in calls
+    assert ("start", "svc1") in calls


### PR DESCRIPTION
## Summary
- allow `proxy2vpn vpn restart` to recreate containers with `--force`
- document the `--force` flag for the restart command
- test forced restart across all services

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b4531dba0832fbe9cbef02df972c4