### PR TITLE
feat: recreate containers by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,6 @@ uv run proxy2vpn <command> [args]
 uv run proxy2vpn profile create myprofile profiles/myprofile.env
 uv run proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn
 uv run proxy2vpn vpn start vpn1
-uv run proxy2vpn vpn start --force vpn1
 uv run proxy2vpn vpn list --diagnose
 uv run proxy2vpn vpn start --all
 uv run proxy2vpn servers list-providers

--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ proxy2vpn --help
 4. Create and start a VPN service:
    ```bash
    proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn --location "New York"
-   proxy2vpn vpn start vpn1
-   # Use --force to recreate the container if it already exists
-   # proxy2vpn vpn start --force vpn1
+   proxy2vpn vpn start vpn1  # container is recreated from compose.yml
    ```
 
 5. View status and test connectivity:
@@ -87,9 +85,9 @@ proxy2vpn --help
 ### VPN services
 - `proxy2vpn vpn create NAME PROFILE [--port PORT] [--provider PROVIDER] [--location LOCATION]`
 - `proxy2vpn vpn list [--diagnose] [--ips-only]`
-- `proxy2vpn vpn start [NAME | --all] [--force]`
+- `proxy2vpn vpn start [NAME | --all]`
 - `proxy2vpn vpn stop [NAME | --all]`
-- `proxy2vpn vpn restart [NAME | --all] [--force]`
+- `proxy2vpn vpn restart [NAME | --all]`
 - `proxy2vpn vpn logs NAME [--lines N] [--follow]`
 - `proxy2vpn vpn delete [NAME | --all]`
 - `proxy2vpn vpn test NAME`

--- a/news/002.feature.md
+++ b/news/002.feature.md
@@ -1,0 +1,1 @@
+feat: default VPN start, stop, and restart commands now recreate containers, removing the `--force` flag

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -169,7 +169,7 @@ def test_recreate_vpn_container():
     docker_ops.remove_container(service.name)
 
 
-def test_start_all_vpn_containers_force(monkeypatch):
+def test_start_all_vpn_containers_recreates(monkeypatch):
     svc = docker_ops.VPNService(
         name="svc",
         port=1,
@@ -202,17 +202,9 @@ def test_start_all_vpn_containers_force(monkeypatch):
         called["recreate"] += 1
         return DummyContainer()
 
-    class FakeClient:
-        class Containers:
-            def list(self, all=True):
-                return []
-
-        containers = Containers()
-
     monkeypatch.setattr(docker_ops, "recreate_vpn_container", fake_recreate)
-    monkeypatch.setattr(docker_ops, "_client", lambda: FakeClient())
     monkeypatch.setattr(docker_ops, "_retry", lambda func, **kw: func())
 
-    results = docker_ops.start_all_vpn_containers(Manager(), force=True)
-    assert results == [("svc", True)]
+    results = docker_ops.start_all_vpn_containers(Manager())
+    assert results == ["svc"]
     assert called["recreate"] == 1

--- a/tests/test_vpn_restart_recreate.py
+++ b/tests/test_vpn_restart_recreate.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 from proxy2vpn import cli, docker_ops
 
 
-def test_vpn_restart_all_force(monkeypatch):
+def test_vpn_restart_all_recreates(monkeypatch):
     runner = CliRunner()
 
     dummy_mgr = SimpleNamespace(
@@ -33,7 +33,7 @@ def test_vpn_restart_all_force(monkeypatch):
     monkeypatch.setattr(docker_ops, "recreate_vpn_container", fake_recreate)
     monkeypatch.setattr(docker_ops, "start_container", fake_start)
 
-    result = runner.invoke(cli.app, ["vpn", "restart", "--all", "--force"])
+    result = runner.invoke(cli.app, ["vpn", "restart", "--all"])
     assert result.exit_code == 0
     assert "Recreated and restarted svc1" in result.stdout
     assert ("recreate", "svc1") in calls


### PR DESCRIPTION
## Summary
- default `vpn start`, `vpn stop`, and `vpn restart` commands recreate containers using compose.yml
- drop `--force` flag and update docs accordingly
- cover recreation flow with tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b491dea7c832f8c74298fd99c0a30