### PR TITLE
feat: sync profile allocation with compose services

### DIFF
--- a/news/102.feature.md
+++ b/news/102.feature.md
@@ -1,0 +1,1 @@
+feat: sync fleet status with compose services and include per-country/profile counts

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -2,6 +2,8 @@ import pytest
 from pathlib import Path
 
 from proxy2vpn.fleet_manager import FleetConfig, FleetManager
+from proxy2vpn.compose_manager import ComposeManager
+from proxy2vpn.models import Profile, VPNService
 
 
 @pytest.fixture
@@ -61,3 +63,74 @@ def test_plan_deployment_sanitizes_and_limits(fleet_manager, monkeypatch):
     assert service.name == "prov-united-states-new-york"
     assert service.profile == "acc1"
     assert service.port == 21000
+
+
+def test_get_fleet_status_reconstructs_allocator(tmp_path):
+    compose_path = tmp_path / "compose.yml"
+    ComposeManager.create_initial_compose(compose_path, force=True)
+    manager = ComposeManager(compose_path)
+
+    env1 = tmp_path / "acc1.env"
+    env1.write_text("KEY=value\n")
+    env2 = tmp_path / "acc2.env"
+    env2.write_text("KEY=value\n")
+
+    manager.add_profile(Profile(name="acc1", env_file=str(env1)))
+    manager.add_profile(Profile(name="acc2", env_file=str(env2)))
+
+    svc1 = VPNService(
+        name="prov-a-city1",
+        port=20000,
+        provider="prov",
+        profile="acc1",
+        location="city1",
+        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city1"},
+        labels={
+            "vpn.type": "vpn",
+            "vpn.port": "20000",
+            "vpn.provider": "prov",
+            "vpn.profile": "acc1",
+            "vpn.location": "city1",
+        },
+    )
+    svc2 = VPNService(
+        name="prov-a-city2",
+        port=20001,
+        provider="prov",
+        profile="acc1",
+        location="city2",
+        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city2"},
+        labels={
+            "vpn.type": "vpn",
+            "vpn.port": "20001",
+            "vpn.provider": "prov",
+            "vpn.profile": "acc1",
+            "vpn.location": "city2",
+        },
+    )
+    svc3 = VPNService(
+        name="prov-b-city3",
+        port=20002,
+        provider="prov",
+        profile="acc2",
+        location="city3",
+        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city3"},
+        labels={
+            "vpn.type": "vpn",
+            "vpn.port": "20002",
+            "vpn.provider": "prov",
+            "vpn.profile": "acc2",
+            "vpn.location": "city3",
+        },
+    )
+
+    manager.add_service(svc1)
+    manager.add_service(svc2)
+    manager.add_service(svc3)
+
+    fm = FleetManager(compose_file_path=compose_path)
+    status = fm.get_fleet_status()
+
+    assert status["total_services"] == 3
+    assert status["profile_counts"] == {"acc1": 2, "acc2": 1}
+    assert status["country_counts"] == {"a": 2, "b": 1}


### PR DESCRIPTION
## Summary
- rebuild profile allocator state from compose services
- refresh fleet status to return per-country and per-profile counts
- test allocator reconstruction from compose

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b67bf6eec832fb14d6e38c7ac3562