### PR TITLE
feat: validate fleet server locations

### DIFF
--- a/news/103.feature.md
+++ b/news/103.feature.md
@@ -1,0 +1,1 @@
+Add server location validation to fleet deployment.


### PR DESCRIPTION
## Summary
- validate fleet deployment server locations before starting services
- skip invalid cities and surface results in console output
- test skipping of invalid locations during fleet deployment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b72f23548832f8acb48af0d3e3527