### PR TITLE
feat: add async IP fetch helper

### DIFF
--- a/news/105.feature.md
+++ b/news/105.feature.md
@@ -1,0 +1,1 @@
+Add async IP fetching via aiohttp with concurrent service queries and provide a helper to run async Typer commands, now with safeguards against nested event loops.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "ruamel.yaml",
     "docker",
     "requests",
+    "aiohttp",
     "filelock",
     "psutil",
 ]

--- a/src/proxy2vpn/ip_utils.py
+++ b/src/proxy2vpn/ip_utils.py
@@ -2,24 +2,67 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Mapping
 
-import requests
+import aiohttp
 
 IP_SERVICES = ("https://ipinfo.io/ip", "https://ifconfig.me")
 
 
-def fetch_ip(proxies: Mapping[str, str] | None = None, timeout: int = 5) -> str:
-    """Return the public IP address using external services.
-
-    Tries multiple providers and returns the first successful response.
-    """
-    for url in IP_SERVICES:
-        try:
-            resp = requests.get(url, proxies=proxies, timeout=timeout)
-            ip = resp.text.strip()
+async def _fetch_ip(session: aiohttp.ClientSession, url: str, proxy: str | None) -> str:
+    """Fetch IP address from a single service."""
+    try:
+        async with session.get(url, proxy=proxy) as resp:
+            text = await resp.text()
+            ip = text.strip()
             if ip:
                 return ip
-        except requests.RequestException:
-            continue
+    except aiohttp.ClientError:
+        return ""
     return ""
+
+
+async def fetch_ip_async(
+    proxies: Mapping[str, str] | None = None, timeout: int = 3
+) -> str:
+    """Return the public IP address using external services concurrently."""
+    proxy = None
+    if proxies:
+        proxy = proxies.get("http") or proxies.get("https")
+
+    timeout_cfg = aiohttp.ClientTimeout(total=timeout)
+    connector = aiohttp.TCPConnector(limit=10)
+    async with aiohttp.ClientSession(
+        timeout=timeout_cfg, connector=connector
+    ) as session:
+        tasks = [
+            asyncio.create_task(_fetch_ip(session, url, proxy)) for url in IP_SERVICES
+        ]
+        try:
+            for task in asyncio.as_completed(tasks):
+                ip = await task
+                if ip:
+                    return ip
+        finally:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+    return ""
+
+
+def fetch_ip(proxies: Mapping[str, str] | None = None, timeout: int = 3) -> str:
+    """Return the public IP address in synchronous contexts.
+
+    This helper runs the asynchronous :func:`fetch_ip_async` function using
+    ``asyncio.run``. It must only be used from synchronous code; callers running
+    inside an existing event loop should use :func:`fetch_ip_async` directly to
+    avoid ``RuntimeError`` from nested event loops.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(fetch_ip_async(proxies=proxies, timeout=timeout))
+    raise RuntimeError(
+        "fetch_ip() cannot be called from an async context; use fetch_ip_async()."
+    )

--- a/tests/test_async_helpers.py
+++ b/tests/test_async_helpers.py
@@ -1,0 +1,32 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+# Ensure src package is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn import ip_utils
+from proxy2vpn import typer_ext
+
+
+def test_fetch_ip_disallows_async_use():
+    async def runner():
+        with pytest.raises(RuntimeError):
+            ip_utils.fetch_ip()
+
+    asyncio.run(runner())
+
+
+def test_run_async_disallows_nested_event_loop():
+    async def noop() -> None:
+        pass
+
+    wrapped = typer_ext.run_async(noop)
+
+    async def runner():
+        with pytest.raises(RuntimeError):
+            wrapped()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add aiohttp-based async IP lookup with concurrent service queries
- provide `run_async` helper for Typer commands
- document async IP fetch capability and guard against nested event loops

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b8435e0e8832faba239f7bd5f1ef1