### PR TITLE
feat: fetch container IPs concurrently

### DIFF
--- a/news/106.feature.md
+++ b/news/106.feature.md
@@ -1,0 +1,1 @@
+Speed up VPN service listing by fetching container IPs concurrently using asynchronous helpers.

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -418,6 +418,22 @@ def get_container_ip(container: Container) -> str:
     return ip or "N/A"
 
 
+async def get_container_ip_async(container: Container) -> str:
+    """Asynchronously return the external IP address for a running container.
+
+    This uses :func:`ip_utils.fetch_ip_async` to concurrently query IP services.
+    If the container is not running, lacks a port label or the request fails,
+    ``"N/A"`` is returned.
+    """
+
+    port = container.labels.get("vpn.port")
+    if not port or container.status != "running":
+        return "N/A"
+    proxies = _get_authenticated_proxy_url(container, port)
+    ip = await ip_utils.fetch_ip_async(proxies=proxies)
+    return ip or "N/A"
+
+
 def test_vpn_connection(name: str) -> bool:
     """Return ``True`` if the VPN proxy for NAME appears to work."""
 

--- a/tests/test_cli_vpn_list.py
+++ b/tests/test_cli_vpn_list.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+
+from typer.testing import CliRunner
+
+# Ensure src package is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn import cli, docker_ops
+
+
+def test_vpn_list_ips_only_async(monkeypatch):
+    runner = CliRunner()
+
+    class C:
+        name = "svc"
+        status = "running"
+        labels = {"vpn.port": "8080"}
+
+    monkeypatch.setattr(docker_ops, "get_vpn_containers", lambda all=False: [C()])
+
+    called = {"n": 0}
+
+    async def fake_get_ip(container):
+        called["n"] += 1
+        return "1.2.3.4"
+
+    monkeypatch.setattr(docker_ops, "get_container_ip_async", fake_get_ip)
+    monkeypatch.setattr(cli, "ComposeManager", lambda *a, **k: None)
+
+    result = runner.invoke(cli.app, ["vpn", "list", "--ips-only"])
+    assert result.exit_code == 0
+    assert "svc: 1.2.3.4" in result.stdout
+    assert called["n"] == 1

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -1,5 +1,6 @@
 import pathlib
 import sys
+import asyncio
 
 import pytest
 
@@ -57,6 +58,19 @@ def test_get_container_ip(monkeypatch):
         lambda proxies=None, timeout=5: "1.1.1.1" if proxies else "2.2.2.2",
     )
     assert docker_ops.get_container_ip(C()) == "1.1.1.1"
+
+
+def test_get_container_ip_async(monkeypatch):
+    class C:
+        status = "running"
+        labels = {"vpn.port": "8080"}
+
+    async def fake_fetch_ip_async(proxies=None, timeout=3):
+        return "1.1.1.1" if proxies else "2.2.2.2"
+
+    monkeypatch.setattr(docker_ops.ip_utils, "fetch_ip_async", fake_fetch_ip_async)
+    result = asyncio.run(docker_ops.get_container_ip_async(C()))
+    assert result == "1.1.1.1"
 
 
 def test_test_vpn_connection(monkeypatch):


### PR DESCRIPTION
## Summary
- fetch container IP addresses concurrently using async helper
- add async-aware tests for Docker ops and CLI `vpn list`
- document change in news fragment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689b8b4d9dbc832f9298cdf0e4dc9124