### PR TITLE
feat: show location in vpn list

### DIFF
--- a/news/location-column.feature.md
+++ b/news/location-column.feature.md
@@ -1,0 +1,1 @@
+Add location column to `proxy2vpn vpn list` output.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -320,6 +320,7 @@ async def vpn_list(
     table.add_column("Name", style="green")
     table.add_column("Port")
     table.add_column("Profile")
+    table.add_column("Location")
     table.add_column("Status")
     table.add_column("IP")
     if diagnose:
@@ -343,6 +344,7 @@ async def vpn_list(
             svc.name,
             str(svc.port),
             svc.profile,
+            svc.location,
             f"[{status_style}]{status}[/{status_style}]",
             ip,
         ]

--- a/tests/test_cli_vpn_list.py
+++ b/tests/test_cli_vpn_list.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from proxy2vpn import cli, docker_ops
+from proxy2vpn.models import VPNService
 
 
 def test_vpn_list_ips_only_async(monkeypatch):
@@ -32,3 +33,43 @@ def test_vpn_list_ips_only_async(monkeypatch):
     assert result.exit_code == 0
     assert "svc: 1.2.3.4" in result.stdout
     assert called["n"] == 1
+
+
+def test_vpn_list_includes_location(monkeypatch):
+    runner = CliRunner()
+
+    svc = VPNService(
+        name="svc",
+        port=8080,
+        provider="prov",
+        profile="pro",
+        location="US",
+        environment={},
+        labels={},
+    )
+
+    class DummyComposeManager:
+        def __init__(self, *a, **k):
+            pass
+
+        def list_services(self):
+            return [svc]
+
+    class Container:
+        name = "svc"
+        status = "running"
+
+    monkeypatch.setattr(
+        docker_ops, "get_vpn_containers", lambda all=True: [Container()]
+    )
+
+    async def fake_get_ip(container):
+        return "1.2.3.4"
+
+    monkeypatch.setattr(docker_ops, "get_container_ip_async", fake_get_ip)
+    monkeypatch.setattr(cli, "ComposeManager", DummyComposeManager)
+
+    result = runner.invoke(cli.app, ["vpn", "list"])
+    assert result.exit_code == 0
+    assert "Location" in result.stdout
+    assert "US" in result.stdout


### PR DESCRIPTION
## Summary
- display VPN location in `vpn list` output
- cover location column with unit test
- document change in news fragment

## Testing
- `make fmt`
- `make test` *(fails: Cannot connect to host raw.githubusercontent.com:443)*
- `uv run --with pytest pytest tests/test_cli_vpn_list.py`


------
https://chatgpt.com/codex/tasks/task_e_689b999b13e8832f81c6781e08e377d6