### PR TITLE
fix: ignore HTML when resolving public IP

### DIFF
--- a/news/fetch-ip-html.bugfix.md
+++ b/news/fetch-ip-html.bugfix.md
@@ -1,0 +1,1 @@
+- handle non-IP responses from external services when retrieving public IPs

--- a/tests/test_ip_utils.py
+++ b/tests/test_ip_utils.py
@@ -1,0 +1,16 @@
+import pathlib
+import sys
+
+# Ensure src package is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn import ip_utils
+
+
+def test_parse_ip_from_html():
+    html = "<html><body>IP is 203.0.113.5</body></html>"
+    assert ip_utils._parse_ip(html) == "203.0.113.5"
+
+
+def test_parse_ip_invalid_text():
+    assert ip_utils._parse_ip("<html></html>") == ""


### PR DESCRIPTION
## Summary
- validate IP fetch responses and skip HTML content
- cover IP parsing against HTML responses

## Testing
- `make fmt`
- `make lint`
- `make test` 
------
https://chatgpt.com/codex/tasks/task_e_689b9da2e518832fb07bde1b483612bc