### PR TITLE
feat: add proxy export command

### DIFF
--- a/news/123.feature.md
+++ b/news/123.feature.md
@@ -1,0 +1,1 @@
+Add `vpn export-proxies` command to export running VPN proxies to a CSV file.

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable, Iterator, Callable, Any
 import time
+import asyncio
 
 from .compose_manager import ComposeManager
 from .diagnostics import DiagnosticAnalyzer, DiagnosticResult
@@ -432,6 +433,71 @@ async def get_container_ip_async(container: Container) -> str:
     proxies = _get_authenticated_proxy_url(container, port)
     ip = await ip_utils.fetch_ip_async(proxies=proxies)
     return ip or "N/A"
+
+
+async def collect_proxy_info(include_credentials: bool = True) -> list[dict[str, str]]:
+    """Return proxy connection details for VPN containers.
+
+    Parameters
+    ----------
+    include_credentials:
+        Include authentication credentials in the result. When ``False``,
+        ``username`` and ``password`` fields are returned empty.
+
+    Returns
+    -------
+    list of dict
+        Each dict contains ``host``, ``port``, ``username``, ``password``,
+        ``location`` and ``status`` keys describing a VPN proxy.
+    """
+
+    try:
+        containers = get_vpn_containers(all=True)
+    except RuntimeError:
+        return []
+
+    async def _ip_or_empty(container: Container) -> str:
+        if container.status != "running":
+            return ""
+        ip = await get_container_ip_async(container)
+        return "" if ip == "N/A" else ip
+
+    ips = await asyncio.gather(*[_ip_or_empty(c) for c in containers])
+    results: list[dict[str, str]] = []
+    for container, ip in zip(containers, ips):
+        env_list = (
+            container.attrs.get("Config", {}).get("Env", [])
+            if getattr(container, "attrs", None)
+            else []
+        )
+        env_vars = {
+            k: v for k, v in (var.split("=", 1) for var in env_list if "=" in var)
+        }
+        username = env_vars.get("HTTPPROXY_USER", "") if include_credentials else ""
+        password = env_vars.get("HTTPPROXY_PASSWORD", "") if include_credentials else ""
+        port = container.labels.get("vpn.port", "")
+        location = container.labels.get("vpn.location", "")
+        state = (
+            container.attrs.get("State", {})
+            if getattr(container, "attrs", None)
+            else {}
+        )
+        if container.status == "running":
+            status = "active"
+        else:
+            status = "error" if state.get("ExitCode", 0) not in {0, None} else "stopped"
+        results.append(
+            {
+                "host": ip,
+                "port": port,
+                "username": username,
+                "password": password,
+                "location": location,
+                "status": status,
+            }
+        )
+
+    return results
 
 
 async def test_vpn_connection_async(name: str) -> bool:

--- a/tests/test_cli_export_proxies.py
+++ b/tests/test_cli_export_proxies.py
@@ -1,0 +1,43 @@
+import sys
+import pathlib
+from typer.testing import CliRunner
+
+# Ensure src package is importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn import cli, docker_ops
+
+
+def test_vpn_export_proxies(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    async def fake_collect(include_credentials: bool = True):
+        return [
+            {
+                "host": "1.2.3.4",
+                "port": "20001",
+                "username": "user" if include_credentials else "",
+                "password": "pass" if include_credentials else "",
+                "location": "London",
+                "status": "active",
+            }
+        ]
+
+    monkeypatch.setattr(docker_ops, "collect_proxy_info", fake_collect)
+
+    out = tmp_path / "proxies.csv"
+    result = runner.invoke(cli.app, ["vpn", "export-proxies", "--output", str(out)])
+    assert result.exit_code == 0
+    lines = out.read_text().splitlines()
+    assert lines[0] == "host,port,username,password,location,status"
+    assert lines[1] == "1.2.3.4,20001,user,pass,London,active"
+
+    out_no = tmp_path / "proxies_no.csv"
+    result2 = runner.invoke(
+        cli.app,
+        ["vpn", "export-proxies", "--output", str(out_no), "--no-auth"],
+    )
+    assert result2.exit_code == 0
+    fields = out_no.read_text().splitlines()[1].split(",")
+    assert fields[2] == ""
+    assert fields[3] == ""


### PR DESCRIPTION
## Summary
- add `vpn export-proxies` CLI command to export running VPN proxies to CSV
- provide Docker helper to gather proxy info with optional credential exclusion
- add tests for proxy export functionality

## Testing
- `make fmt`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_689ba361f4ec832fa0723a7647be5dd1