### PR TITLE
docs: streamline installation instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,15 @@ Proxy2VPN is a Python command-line interface for managing multiple VPN container
 ```bash
 # Install dependencies
 uv sync
+```
 
+> [!NOTE]
+> `uv` is part of the `uv` toolchain. If `uv` isn't installed, get it with:
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
+
+```bash
 # Run Python application
 uv run proxy2vpn <command> [args]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,14 @@
 Thank you for considering a contribution to Proxy2VPN!
 
 ## Getting Started
-- Install dev deps: `uv sync` or `pip install -e ".[dev]"`.
+- Install dev deps: `uv sync` (recommended) or `pip install -e ".[dev]"`.
 - Run the suite: `make fmt-check && make lint && make test`.
+
+> [!NOTE]
+> `uv` is part of the `uv` toolchain. If `uv` isn't installed, get it with:
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 ## Code Style
 - Python 3.10+ with type hints encouraged.

--- a/README.md
+++ b/README.md
@@ -18,28 +18,18 @@ Python command-line interface for managing multiple VPN containers with Docker.
 
 ## Installation
 
-Install `proxy2vpn` from [PyPI](https://pypi.org/project/proxy2vpn/) using your
-preferred Python tool:
-
-### pip
-```bash
-pip install proxy2vpn
-```
-
-### uv
-```bash
-uv tool install proxy2vpn
-```
+Install `proxy2vpn` from [PyPI](https://pypi.org/project/proxy2vpn/) using `uvx`:
 
 ### uvx (run without installing)
 ```bash
 uvx proxy2vpn --help
 ```
 
-### pipx
-```bash
-pipx install proxy2vpn
-```
+> [!NOTE]
+> `uvx` is part of the `uv` toolchain. If `uv` isn't installed, get it with:
+> ```bash
+> curl -LsSf https://astral.sh/uv/install.sh | sh
+> ```
 
 ## Quick Start
 1. Initialize the compose file:

--- a/news/005.doc.md
+++ b/news/005.doc.md
@@ -1,0 +1,1 @@
+Add note on installing uv and streamline installation instructions to use uvx.


### PR DESCRIPTION
## Summary
- simplify install instructions to use uvx and document how to install uv
- clarify install script and propagate note to contributor docs
- add towncrier entry

## Testing
- `make fmt`
- `make lint`
- `make test` *(fails: Cannot connect to host raw.githubusercontent.com:443 ssl:default [Network is unreachable])*

------
https://chatgpt.com/codex/tasks/task_e_689bbf0f42a8832fac64c31e17e8e3a4