### PR TITLE
feat: add optional file logging

### DIFF
--- a/news/006.feature.md
+++ b/news/006.feature.md
@@ -1,0 +1,1 @@
+Add optional file logging; logs are disabled when no file is specified.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -52,6 +52,9 @@ def main(
         help="Path to compose file",
         callback=sanitize_path,
     ),
+    log_file: Path | None = typer.Option(
+        None, "--log-file", help="Write JSON logs to file"
+    ),
     version: bool = typer.Option(
         False,
         "--version",
@@ -61,7 +64,9 @@ def main(
     ),
 ):
     """Store global options in context."""
-    configure_logging()
+    if log_file:
+        log_file = log_file.expanduser().resolve()
+    configure_logging(log_file=log_file)
     if version:
         from . import __version__
 

--- a/src/proxy2vpn/logging_utils.py
+++ b/src/proxy2vpn/logging_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
+from pathlib import Path
 from typing import Any, Dict
 
 
@@ -47,14 +47,23 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(log_record, ensure_ascii=False)
 
 
-def configure_logging(level: int = logging.INFO) -> None:
-    """Configure root logger with JSON formatter."""
+def configure_logging(
+    level: int = logging.INFO, log_file: str | Path | None = None
+) -> None:
+    """Configure root logger with JSON formatter.
 
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(JsonFormatter())
+    If ``log_file`` is provided, logs are written to that file. Otherwise, logs
+    are suppressed so they do not interfere with console output.
+    """
+
     root = logging.getLogger()
     root.handlers.clear()
     root.setLevel(level)
+    if log_file:
+        handler: logging.Handler = logging.FileHandler(log_file)
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler = logging.NullHandler()
     root.addHandler(handler)
 
 

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -14,6 +14,7 @@ def _run_proxy2vpn(args, cwd):
     repo_root = pathlib.Path(__file__).resolve().parents[1]
     env = os.environ.copy()
     env["PYTHONPATH"] = str(repo_root / "src")
+    env["HOME"] = str(cwd)
     return subprocess.run(
         [sys.executable, "-m", "proxy2vpn", *args],
         cwd=cwd,
@@ -24,6 +25,9 @@ def _run_proxy2vpn(args, cwd):
 
 
 def test_init_creates_compose(tmp_path):
+    cache_dir = tmp_path / ".cache" / "proxy2vpn"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "servers.json").write_text("{}")
     result = _run_proxy2vpn(["system", "init"], tmp_path)
     assert result.returncode == 0
     compose = tmp_path / "compose.yml"
@@ -38,6 +42,10 @@ def test_init_creates_compose(tmp_path):
 def test_init_requires_force(tmp_path):
     compose = tmp_path / "compose.yml"
     compose.write_text("services: {}\n")
+
+    cache_dir = tmp_path / ".cache" / "proxy2vpn"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "servers.json").write_text("{}")
 
     result = _run_proxy2vpn(["system", "init"], tmp_path)
     assert result.returncode != 0

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from proxy2vpn.logging_utils import configure_logging, get_logger
+
+
+def test_configure_logging_writes_to_file(tmp_path: Path) -> None:
+    log_file = tmp_path / "app.log"
+    configure_logging(log_file=log_file)
+    logger = get_logger("test")
+    logger.info("hello", extra={"foo": "bar"})
+    data = json.loads(log_file.read_text().strip())
+    assert data["message"] == "hello"
+    assert data["foo"] == "bar"
+
+
+def test_configure_logging_suppresses_logs(capfd) -> None:
+    configure_logging()
+    logger = get_logger("test")
+    logger.info("quiet")
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""


### PR DESCRIPTION
## Summary
- add optional log file configuration with console-only silent default
- expose `--log-file` CLI option
- test logging behavior and isolate init command tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bc112d988832fae440d9c7210472f