### PR TITLE
fix: show message for empty fleet allocation

### DIFF
--- a/news/123.bugfix.md
+++ b/news/123.bugfix.md
@@ -1,0 +1,1 @@
+fix empty profile allocation table output in `fleet status`

--- a/src/proxy2vpn/fleet_commands.py
+++ b/src/proxy2vpn/fleet_commands.py
@@ -272,6 +272,9 @@ def _display_deployment_plan(
 
 def _display_allocation_table(allocation_status: Dict[str, Dict]):
     """Display profile allocation status"""
+    if not allocation_status:
+        console.print("[yellow]No profiles found in fleet[/yellow]")
+        return
 
     table = Table(title="📊 Profile Allocation Status")
     table.add_column("N", style="dim blue")

--- a/tests/test_fleet_allocation_table.py
+++ b/tests/test_fleet_allocation_table.py
@@ -1,0 +1,15 @@
+import io
+from rich.console import Console
+
+from proxy2vpn import fleet_commands
+
+
+def test_display_allocation_table_empty(monkeypatch):
+    buffer = io.StringIO()
+    test_console = Console(file=buffer, force_terminal=False)
+    monkeypatch.setattr(fleet_commands, "console", test_console)
+
+    fleet_commands._display_allocation_table({})
+
+    output = buffer.getvalue()
+    assert "No profiles found in fleet" in output


### PR DESCRIPTION
## Summary
- show warning instead of an empty profile allocation table in `fleet status`
- test profile allocation table output when no profiles are present

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bc82a924c832fb6a564031677754a