### PR TITLE
fix: authenticate fleet health checks

### DIFF
--- a/news/64.bugfix.md
+++ b/news/64.bugfix.md
@@ -1,0 +1,1 @@
+Fix fleet health checks by using authenticated proxy URLs during validation.

--- a/src/proxy2vpn/server_monitor.py
+++ b/src/proxy2vpn/server_monitor.py
@@ -115,13 +115,15 @@ class ServerMonitor:
                 return False
 
             # Test proxy connectivity
-            proxy_url = f"http://localhost:{service.port}"
+            from .docker_ops import _get_authenticated_proxy_url
+
+            proxies = _get_authenticated_proxy_url(container, str(service.port))
             test_url = "http://httpbin.org/ip"
 
             start_time = time.time()
             response = requests.get(
                 test_url,
-                proxies={"http": proxy_url, "https": proxy_url},
+                proxies=proxies,
                 timeout=timeout,
             )
             response_time = time.time() - start_time

--- a/tests/test_server_monitor.py
+++ b/tests/test_server_monitor.py
@@ -1,0 +1,45 @@
+import asyncio
+import types
+
+from proxy2vpn import server_monitor, models, docker_ops
+
+
+class DummyContainer:
+    status = "running"
+    attrs = {"Config": {"Env": ["HTTPPROXY_USER=user", "HTTPPROXY_PASSWORD=pass"]}}
+
+    def reload(self):
+        pass
+
+
+def test_check_service_health_uses_authenticated_proxy(monkeypatch):
+    service = models.VPNService(
+        name="vpn-test",
+        port=8080,
+        provider="",
+        profile="",
+        location="",
+        environment={},
+        labels={},
+    )
+
+    container = DummyContainer()
+
+    captured = {}
+
+    def fake_get(url, proxies, timeout):
+        captured["proxies"] = proxies
+
+        class Resp:
+            status_code = 200
+
+        return Resp()
+
+    monkeypatch.setattr(server_monitor, "requests", types.SimpleNamespace(get=fake_get))
+    monkeypatch.setattr(
+        docker_ops, "get_container_by_service_name", lambda name: container
+    )
+
+    monitor = server_monitor.ServerMonitor(fleet_manager=None)
+    assert asyncio.run(monitor.check_service_health(service))
+    assert captured["proxies"]["http"] == "http://user:pass@localhost:8080"


### PR DESCRIPTION
## Summary
- use authenticated proxy URLs when checking fleet health
- add regression test for proxy auth

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bc9347db0832facc398fdf5c0465b