### PR TITLE
feat: add unique IP option to fleet plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For enterprise-scale deployment across multiple cities and VPN accounts:
 2. Plan a fleet deployment across countries:
    ```bash
    # Deploy across Germany and France with 2 slots on account1, 8 on account2
-   proxy2vpn fleet plan --countries "Germany,France,Netherlands" --profiles "account1:2,account2:8"
+   proxy2vpn fleet plan --countries "Germany,France,Netherlands" --profiles "account1:2,account2:8" --unique-ips
    ```
 
 3. Deploy the planned fleet:
@@ -129,7 +129,7 @@ For enterprise-scale deployment across multiple cities and VPN accounts:
 - `proxy2vpn servers validate-location PROVIDER LOCATION`
 
 ### Fleet management
-- `proxy2vpn fleet plan --countries "Germany,France" --profiles "acc1:2,acc2:8" [--output PLAN_FILE]`
+- `proxy2vpn fleet plan --countries "Germany,France" --profiles "acc1:2,acc2:8" [--output PLAN_FILE] [--unique-ips]`
 - `proxy2vpn fleet deploy [--plan-file PLAN_FILE] [--parallel] [--validate-first] [--dry-run]`
 - `proxy2vpn fleet status [--format table|json|yaml] [--show-allocation] [--show-health]`
 - `proxy2vpn fleet rotate [--country COUNTRY] [--criteria random|performance|load] [--dry-run]`

--- a/news/124.feature.md
+++ b/news/124.feature.md
@@ -1,0 +1,1 @@
+feat: add --unique-ips option to fleet plan to ensure unique city/IP routes

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -867,6 +867,9 @@ def fleet_plan_cmd(
     ),
     output: str = typer.Option("deployment-plan.yaml", help="Save plan to file"),
     validate_servers: bool = typer.Option(True, help="Validate server availability"),
+    unique_ips: bool = typer.Option(
+        False, help="Ensure each service uses a unique city and server IP"
+    ),
 ):
     """Plan bulk VPN deployment across cities"""
     from .fleet_commands import fleet_plan
@@ -880,6 +883,7 @@ def fleet_plan_cmd(
         naming_template,
         output,
         validate_servers,
+        unique_ips,
     )
 
 


### PR DESCRIPTION
## Summary
- add `--unique-ips` option to `fleet plan` for unique city/IP combos
- show hostnames and IPs in deployment plan tables
- include news fragment and tests for unique IP planning

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bcb4ab80c832f8d2163c3eab8e6e0