### PR TITLE
feat: include IP details in diagnostics

### DIFF
--- a/news/diagnostics-ip-info.feature.md
+++ b/news/diagnostics-ip-info.feature.md
@@ -1,0 +1,1 @@
+Include direct and proxied IP addresses in connectivity diagnostics and system diagnose output.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -843,7 +843,8 @@ def system_diagnose(
             )
             if verbose or entry["issues"]:
                 for issue, rec in zip(entry["issues"], entry["recommendations"]):
-                    typer.echo(f"  - {issue}: {rec}")
+                    suffix = f": {rec}" if rec else ""
+                    typer.echo(f"  - {issue}{suffix}")
 
     # Reset log level to avoid affecting other commands
     if verbose:

--- a/src/proxy2vpn/diagnostics.py
+++ b/src/proxy2vpn/diagnostics.py
@@ -76,25 +76,37 @@ class DiagnosticAnalyzer:
         }
         direct = ip_utils.fetch_ip()
         proxied = ip_utils.fetch_ip(proxies=proxies)
+        details: list[str] = []
+        if direct:
+            details.append(f"direct={direct}")
+        if proxied:
+            details.append(f"proxied={proxied}")
+        detail_msg = f" ({', '.join(details)})" if details else ""
+
         if not proxied:
             results.append(
                 DiagnosticResult(
                     "connectivity",
                     False,
-                    "Connectivity test failed",
+                    f"Connectivity test failed{detail_msg}",
                     "Ensure VPN container network is reachable.",
                 )
             )
         elif proxied != direct:
             results.append(
-                DiagnosticResult("dns_leak", True, "No DNS leak detected", "")
+                DiagnosticResult(
+                    "dns_leak",
+                    True,
+                    f"No DNS leak detected{detail_msg}",
+                    "",
+                )
             )
         else:
             results.append(
                 DiagnosticResult(
                     "dns_leak",
                     False,
-                    "Possible DNS leak detected",
+                    f"Possible DNS leak detected{detail_msg}",
                     "Check firewall and kill switch settings.",
                 )
             )
@@ -114,26 +126,37 @@ class DiagnosticAnalyzer:
         proxied_task = asyncio.create_task(ip_utils.fetch_ip_async(proxies=proxies))
 
         direct, proxied = await asyncio.gather(direct_task, proxied_task)
+        details: list[str] = []
+        if direct:
+            details.append(f"direct={direct}")
+        if proxied:
+            details.append(f"proxied={proxied}")
+        detail_msg = f" ({', '.join(details)})" if details else ""
 
         if not proxied:
             results.append(
                 DiagnosticResult(
                     "connectivity",
                     False,
-                    "Connectivity test failed",
+                    f"Connectivity test failed{detail_msg}",
                     "Ensure VPN container network is reachable.",
                 )
             )
         elif proxied != direct:
             results.append(
-                DiagnosticResult("dns_leak", True, "No DNS leak detected", "")
+                DiagnosticResult(
+                    "dns_leak",
+                    True,
+                    f"No DNS leak detected{detail_msg}",
+                    "",
+                )
             )
         else:
             results.append(
                 DiagnosticResult(
                     "dns_leak",
                     False,
-                    "Possible DNS leak detected",
+                    f"Possible DNS leak detected{detail_msg}",
                     "Check firewall and kill switch settings.",
                 )
             )


### PR DESCRIPTION
## Summary
- show direct and proxied IPs in connectivity diagnostics
- print diagnostic messages cleanly in `system diagnose`
- test diagnostics include IP information

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bd1233b2c832fa17730726e09c778