### PR TITLE
feat: add control port support

### DIFF
--- a/news/control-port.feature.md
+++ b/news/control-port.feature.md
@@ -1,0 +1,1 @@
+Add support for control server port allocation and validation.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -202,10 +202,12 @@ def profile_apply(
         )
     if port == 0:
         port = manager.next_available_port(config.DEFAULT_PORT_START)
+    control_port = manager.next_available_port(port + 1)
     env = {"VPN_SERVICE_PROVIDER": config.DEFAULT_PROVIDER}
     labels = {
         "vpn.type": "vpn",
         "vpn.port": str(port),
+        "vpn.control_port": str(control_port),
         "vpn.provider": config.DEFAULT_PROVIDER,
         "vpn.profile": profile,
         "vpn.location": "",
@@ -213,6 +215,7 @@ def profile_apply(
     svc = VPNService(
         name=service,
         port=port,
+        control_port=control_port,
         provider=config.DEFAULT_PROVIDER,
         profile=profile,
         location="",
@@ -221,7 +224,7 @@ def profile_apply(
     )
     manager.add_service(svc)
     console.print(
-        f"[green]✓[/green] Service '{service}' created from profile '{profile}' on port {port}."
+        f"[green]✓[/green] Service '{service}' created from profile '{profile}' on port {port} (control {control_port}).",
     )
 
 

--- a/src/proxy2vpn/compose_manager.py
+++ b/src/proxy2vpn/compose_manager.py
@@ -181,6 +181,9 @@ class ComposeManager:
 
         port = start or 20000
         used = {svc.port for svc in self.list_services()}
+        used.update(
+            {svc.control_port for svc in self.list_services() if svc.control_port}
+        )
         while port in used:
             port += 1
         return port

--- a/src/proxy2vpn/compose_validator.py
+++ b/src/proxy2vpn/compose_validator.py
@@ -16,7 +16,7 @@ class ValidationError(Exception):
 REQUIRED_TOP_LEVEL_KEYS = ["services"]
 PROFILE_REQUIRED_FIELDS = ["image", "cap_add", "devices", "env_file"]
 SERVICE_REQUIRED_FIELDS = ["ports", "environment", "labels"]
-LABEL_REQUIRED_FIELDS = ["vpn.type", "vpn.port", "vpn.profile"]
+LABEL_REQUIRED_FIELDS = ["vpn.type", "vpn.port", "vpn.control_port", "vpn.profile"]
 
 
 def _parse_yaml(path: Path):

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -131,11 +131,14 @@ def create_vpn_container(service: VPNService, profile: Profile) -> Container:
         env = _load_env_file(profile.env_file)
         env.update(service.environment)
         ensure_network()
+        port_bindings = {"8888/tcp": service.port}
+        if service.control_port:
+            port_bindings["8000/tcp"] = service.control_port
         container = client.containers.create(
             profile.image,
             name=service.name,
             detach=True,
-            ports={"8888/tcp": service.port},
+            ports=port_bindings,
             environment=env,
             labels=service.labels,
             cap_add=profile.cap_add,

--- a/tests/test_compose.yml
+++ b/tests/test_compose.yml
@@ -17,20 +17,24 @@ services:
     <<: *vpn-base-test
     ports:
       - "0.0.0.0:9999:8888/tcp"
+      - "0.0.0.0:19999:8000/tcp"
     environment:
       - SERVER_CITIES=New York
     labels:
       vpn.type: vpn
       vpn.port: "9999"
+      vpn.control_port: "19999"
       vpn.profile: test
 
   testvpn2:
     <<: *vpn-base-test
     ports:
       - "0.0.0.0:9998:8888/tcp"
+      - "0.0.0.0:19998:8000/tcp"
     environment:
       - SERVER_CITIES=Chicago
     labels:
       vpn.type: vpn
       vpn.port: "9998"
+      vpn.control_port: "19998"
       vpn.profile: test

--- a/tests/test_compose_validator.py
+++ b/tests/test_compose_validator.py
@@ -29,13 +29,13 @@ def test_valid_compose(tmp_path):
             services:
               svc:
                 <<: *vpn-base-test
-                ports:
-                  - "20000:1194/tcp"
+                ports: ["20000:1194/tcp", "20001:8000/tcp"]
                 environment:
                   VAR: "1"
                 labels:
                   vpn.type: vpn
                   vpn.port: "20000"
+                  vpn.control_port: "20001"
                   vpn.profile: test
             """
         )
@@ -62,11 +62,12 @@ def test_orphaned_profile(tmp_path):
             services:
               svc:
                 <<: *vpn-base-test
-                ports: ["20000:1194/tcp"]
+                ports: ["20000:1194/tcp", "20001:8000/tcp"]
                 environment: {{VAR: "1"}}
                 labels:
                   vpn.type: vpn
                   vpn.port: "20000"
+                  vpn.control_port: "20001"
                   vpn.profile: test
             """
         )
@@ -89,19 +90,21 @@ def test_duplicate_ports(tmp_path):
             services:
               one:
                 <<: *vpn-base-test
-                ports: ["20000:1194/tcp"]
+                ports: ["20000:1194/tcp", "20001:8000/tcp"]
                 environment: {{VAR: "1"}}
                 labels:
                   vpn.type: vpn
                   vpn.port: "20000"
+                  vpn.control_port: "20001"
                   vpn.profile: test
               two:
                 <<: *vpn-base-test
-                ports: ["20000:1194/tcp"]
+                ports: ["20002:1194/tcp", "20001:8000/tcp"]
                 environment: {{VAR: "1"}}
                 labels:
                   vpn.type: vpn
-                  vpn.port: "20000"
+                  vpn.port: "20002"
+                  vpn.control_port: "20001"
                   vpn.profile: test
             """
         )
@@ -116,19 +119,20 @@ def test_missing_profile_field(tmp_path):
     compose.write_text(
         dedent(
             f"""
-            x-vpn-base-test: &vpn-base-test
-              cap_add: [NET_ADMIN]
-              devices: [/dev/net/tun]
-              env_file: {env}
-            services:
-              svc:
-                <<: *vpn-base-test
-                ports: ["20000:1194/tcp"]
-                environment: {{VAR: "1"}}
-                labels:
-                  vpn.type: vpn
-                  vpn.port: "20000"
-                  vpn.profile: test
+              x-vpn-base-test: &vpn-base-test
+                cap_add: [NET_ADMIN]
+                devices: [/dev/net/tun]
+                env_file: {env}
+              services:
+                svc:
+                  <<: *vpn-base-test
+                  ports: ["20000:1194/tcp", "20001:8000/tcp"]
+                  environment: {{VAR: "1"}}
+                  labels:
+                    vpn.type: vpn
+                    vpn.port: "20000"
+                    vpn.control_port: "20001"
+                    vpn.profile: test
             """
         )
     )

--- a/tests/test_profile_apply.py
+++ b/tests/test_profile_apply.py
@@ -33,5 +33,6 @@ def test_profile_apply(tmp_path):
         assert "test" in profiles
         cli.profile_apply(ctx, "test", "vpn3", port=7777)
     manager = ComposeManager(compose_path)
-    services = {s.name for s in manager.list_services()}
-    assert "vpn3" in services
+    svc = manager.get_service("vpn3")
+    assert svc.control_port != 0
+    assert svc.labels.get("vpn.control_port") == str(svc.control_port)


### PR DESCRIPTION
## Summary
- add control_port to VPNService and parse/serialize compose port 8000
- publish control server port when creating VPN containers
- allocate and validate control_port across compose management

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c581e5d0c832f8de89c87ed6d33f9