### PR TITLE
feat: add control client helpers

### DIFF
--- a/news/control-client.feature.md
+++ b/news/control-client.feature.md
@@ -1,0 +1,2 @@
+Add aiohttp-based control client helpers for interacting with the control API.
+

--- a/src/proxy2vpn/__init__.py
+++ b/src/proxy2vpn/__init__.py
@@ -16,5 +16,6 @@ __all__ = [
     "models",
     "config",
     "server_manager",
+    "control_client",
     "__version__",
 ]

--- a/src/proxy2vpn/control_client.py
+++ b/src/proxy2vpn/control_client.py
@@ -1,0 +1,50 @@
+"""Client helpers for interacting with the gluetun control API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+
+
+class ControlClientError(RuntimeError):
+    """Raised when the control API returns an error."""
+
+
+def _build_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+async def _request(method: str, url: str, action: str, **kwargs: Any) -> Any:
+    try:
+        timeout = aiohttp.ClientTimeout(total=5)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.request(method, url, **kwargs) as response:
+                response.raise_for_status()
+                return await response.json(content_type=None)
+    except aiohttp.ClientResponseError as exc:  # pragma: no cover - handled for clarity
+        raise ControlClientError(f"{action}: {exc.status} {exc.message}") from exc
+    except aiohttp.ClientError as exc:  # pragma: no cover - network issues
+        raise ControlClientError(f"{action}: {exc}") from exc
+
+
+async def get_status(base_url: str) -> dict[str, Any]:
+    """Return the current control server status."""
+    url = _build_url(base_url, "status")
+    return await _request("get", url, "Failed to get status")
+
+
+async def set_openvpn_status(base_url: str, status: bool) -> dict[str, Any]:
+    """Enable or disable OpenVPN through the control API."""
+    url = _build_url(base_url, "openvpn")
+    payload = {"status": status}
+    return await _request("post", url, "Failed to set OpenVPN status", json=payload)
+
+
+async def get_public_ip(base_url: str) -> str:
+    """Return the public IP reported by the control API."""
+    url = _build_url(base_url, "ip")
+    data = await _request("get", url, "Failed to get public IP")
+    if isinstance(data, dict):
+        return data.get("ip", "")
+    return str(data)

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -1,0 +1,61 @@
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn import control_client
+
+
+BASE_URL = "http://localhost:8000"
+
+
+def test_get_status_calls_correct_url(monkeypatch):
+    called: dict[str, str] = {}
+
+    async def fake_request(
+        method, url, action, **kwargs
+    ):  # pragma: no cover - simple mock
+        called["method"] = method
+        called["url"] = url
+        return {"status": "ok"}
+
+    monkeypatch.setattr(control_client, "_request", fake_request)
+    result = asyncio.run(control_client.get_status(BASE_URL))
+    assert result == {"status": "ok"}
+    assert called["method"] == "get"
+    assert called["url"] == f"{BASE_URL}/status"
+
+
+def test_set_openvpn_status_posts_payload(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_request(
+        method, url, action, **kwargs
+    ):  # pragma: no cover - simple mock
+        called["method"] = method
+        called["url"] = url
+        called["json"] = kwargs.get("json")
+        return {"status": kwargs["json"]["status"]}
+
+    monkeypatch.setattr(control_client, "_request", fake_request)
+    result = asyncio.run(control_client.set_openvpn_status(BASE_URL, True))
+    assert result == {"status": True}
+    assert called["method"] == "post"
+    assert called["url"] == f"{BASE_URL}/openvpn"
+    assert called["json"] == {"status": True}
+
+
+def test_get_public_ip_returns_ip(monkeypatch):
+    called: dict[str, str] = {}
+
+    async def fake_request(
+        method, url, action, **kwargs
+    ):  # pragma: no cover - simple mock
+        called["url"] = url
+        return {"ip": "1.2.3.4"}
+
+    monkeypatch.setattr(control_client, "_request", fake_request)
+    ip = asyncio.run(control_client.get_public_ip(BASE_URL))
+    assert ip == "1.2.3.4"
+    assert called["url"] == f"{BASE_URL}/ip"


### PR DESCRIPTION
## Summary
- add control_client module for gluetun API using aiohttp
- expose control_client in package __all__
- add unit tests for async control client helpers

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c60e78ea8832fb77985d02f25bc08