### PR TITLE
feat: add VPN control CLI commands

### DIFF
--- a/news/cli-control-commands.feature.md
+++ b/news/cli-control-commands.feature.md
@@ -1,0 +1,1 @@
+Added CLI commands for querying VPN control API status, public IP, and restarting tunnels.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -19,6 +19,7 @@ from .compose_manager import ComposeManager
 from .models import Profile, VPNService
 from .server_manager import ServerManager
 from .compose_validator import validate_compose
+from . import control_client
 from .utils import abort
 from .validators import sanitize_name, sanitize_path, validate_port
 from .logging_utils import configure_logging, get_logger, set_log_level
@@ -40,6 +41,21 @@ app.add_typer(fleet_app, name="fleet")
 logger = get_logger(__name__)
 
 console = Console()
+
+
+def _service_control_base_url(ctx: typer.Context, name: str) -> str:
+    compose_file: Path = ctx.obj.get("compose_file", config.COMPOSE_FILE)
+    manager = ComposeManager(compose_file)
+    try:
+        svc = manager.get_service(name)
+    except KeyError:
+        abort(f"Service '{name}' not found")
+    if not svc.control_port:
+        abort(
+            f"Service '{name}' has no control port published",
+            "Expose port 8000 and set label 'vpn.control_port'",
+        )
+    return f"http://localhost:{svc.control_port}/v1"
 
 
 @app.callback(invoke_without_command=True)
@@ -674,6 +690,57 @@ async def vpn_export_proxies(
     console.print(
         f"[green]\u2713[/green] Exported {len(proxies)} proxies to '{output}'."
     )
+
+
+@vpn_app.command("status")
+@run_async
+async def vpn_status(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., callback=sanitize_name),
+):
+    """Show control server status for SERVICE.
+
+    Requires the service to publish port 8000 and set the `vpn.control_port` label.
+    Optional basic auth can be provided via the `GLUETUN_CONTROL_AUTH` env var.
+    """
+
+    base_url = _service_control_base_url(ctx, service)
+    data = await control_client.get_status(base_url)
+    console.print_json(data=data)
+
+
+@vpn_app.command("public-ip")
+@run_async
+async def vpn_public_ip(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., callback=sanitize_name),
+):
+    """Show public IP reported by the control API for SERVICE.
+
+    Requires the service to publish port 8000 and set the `vpn.control_port` label.
+    Optional basic auth can be provided via the `GLUETUN_CONTROL_AUTH` env var.
+    """
+
+    base_url = _service_control_base_url(ctx, service)
+    ip = await control_client.get_public_ip(base_url)
+    console.print(ip)
+
+
+@vpn_app.command("restart-tunnel")
+@run_async
+async def vpn_restart_tunnel(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., callback=sanitize_name),
+):
+    """Restart the VPN tunnel for SERVICE via the control API.
+
+    Requires the service to publish port 8000 and set the `vpn.control_port` label.
+    Optional basic auth can be provided via the `GLUETUN_CONTROL_AUTH` env var.
+    """
+
+    base_url = _service_control_base_url(ctx, service)
+    await control_client.restart_tunnel(base_url)
+    console.print("[green]\u2713[/green] Tunnel restart requested.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/proxy2vpn/control_client.py
+++ b/src/proxy2vpn/control_client.py
@@ -48,3 +48,10 @@ async def get_public_ip(base_url: str) -> str:
     if isinstance(data, dict):
         return data.get("ip", "")
     return str(data)
+
+
+async def restart_tunnel(base_url: str) -> dict[str, Any]:
+    """Restart the VPN tunnel through the control API."""
+    url = _build_url(base_url, "openvpn/status")
+    payload = {"status": "restarted"}
+    return await _request("put", url, "Failed to restart tunnel", json=payload)

--- a/tests/test_cli_control.py
+++ b/tests/test_cli_control.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from typer.testing import CliRunner
+
+from proxy2vpn import cli, control_client
+
+
+COMPOSE_FILE = pathlib.Path(__file__).with_name("test_compose.yml")
+
+
+def test_vpn_status_uses_control_port(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    async def fake_get_status(base_url):
+        called["base_url"] = base_url
+        return {"status": "ok"}
+
+    monkeypatch.setattr(control_client, "get_status", fake_get_status)
+
+    result = runner.invoke(
+        cli.app,
+        ["--compose-file", str(COMPOSE_FILE), "vpn", "status", "testvpn1"],
+    )
+    assert result.exit_code == 0
+    assert called["base_url"] == "http://localhost:19999/v1"
+
+
+def test_vpn_public_ip_uses_control_port(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    async def fake_get_public_ip(base_url):
+        called["base_url"] = base_url
+        return "1.2.3.4"
+
+    monkeypatch.setattr(control_client, "get_public_ip", fake_get_public_ip)
+
+    result = runner.invoke(
+        cli.app,
+        ["--compose-file", str(COMPOSE_FILE), "vpn", "public-ip", "testvpn1"],
+    )
+    assert result.exit_code == 0
+    assert called["base_url"] == "http://localhost:19999/v1"
+
+
+def test_vpn_restart_tunnel_uses_control_port(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    async def fake_restart_tunnel(base_url):
+        called["base_url"] = base_url
+        return {}
+
+    monkeypatch.setattr(control_client, "restart_tunnel", fake_restart_tunnel)
+
+    result = runner.invoke(
+        cli.app,
+        ["--compose-file", str(COMPOSE_FILE), "vpn", "restart-tunnel", "testvpn1"],
+    )
+    assert result.exit_code == 0
+    assert called["base_url"] == "http://localhost:19999/v1"

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -59,3 +59,20 @@ def test_get_public_ip_returns_ip(monkeypatch):
     ip = asyncio.run(control_client.get_public_ip(BASE_URL))
     assert ip == "1.2.3.4"
     assert called["url"] == f"{BASE_URL}/ip"
+
+
+def test_restart_tunnel_puts_status(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_request(method, url, action, **kwargs):
+        called["method"] = method
+        called["url"] = url
+        called["json"] = kwargs.get("json")
+        return {"status": "restarted"}
+
+    monkeypatch.setattr(control_client, "_request", fake_request)
+    result = asyncio.run(control_client.restart_tunnel(BASE_URL))
+    assert result == {"status": "restarted"}
+    assert called["method"] == "put"
+    assert called["url"] == f"{BASE_URL}/openvpn/status"
+    assert called["json"] == {"status": "restarted"}


### PR DESCRIPTION
## Summary
- add `vpn status`, `vpn public-ip`, and `vpn restart-tunnel` commands
- support restarting tunnels via control API
- test CLI control commands and add changelog entry

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c65e93e74832fbe28f386a0ba6d5f