### PR TITLE
docs: document HTTP control server

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ uvx proxy2vpn --help
    proxy2vpn vpn test vpn1
    ```
 
+## HTTP Control Server
+
+Each VPN container exposes an HTTP control API on port `8000`. Publish this port and set the `vpn.control_port` label in your compose file to enable control commands.
+
+### Sample compose snippet
+
+```yaml
+services:
+  vpn1:
+    image: qmcgaw/gluetun
+    ports:
+      - "8888:8888/tcp"    # proxy port
+      - "19999:8000/tcp"   # control server
+    labels:
+      vpn.type: vpn
+      vpn.port: "8888"
+      vpn.control_port: "19999"
+      vpn.profile: myprofile
+```
+
+### CLI commands
+
+```bash
+proxy2vpn vpn status vpn1
+proxy2vpn vpn public-ip vpn1
+proxy2vpn vpn restart-tunnel vpn1
+```
+
 ## Fleet Management
 
 For enterprise-scale deployment across multiple cities and VPN accounts:

--- a/news/http-control-server.feature.md
+++ b/news/http-control-server.feature.md
@@ -1,0 +1,1 @@
+Add HTTP control server on port 8000 with CLI commands for status, public IP, and tunnel restart.


### PR DESCRIPTION
## Summary
- describe control API on port 8000 and show compose/CLI examples
- add news fragment for new HTTP control server functionality

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c74e16f18832fa871d2ca2e06ca69