### PR TITLE
feat: add aiohttp HTTP client with retry support

### DIFF
--- a/news/http-client.feature.md
+++ b/news/http-client.feature.md
@@ -1,0 +1,1 @@
+Added asynchronous HTTP client with configurable retries and request timing metrics.

--- a/src/proxy2vpn/__init__.py
+++ b/src/proxy2vpn/__init__.py
@@ -17,5 +17,6 @@ __all__ = [
     "config",
     "server_manager",
     "control_client",
+    "http_client",
     "__version__",
 ]

--- a/src/proxy2vpn/http_client.py
+++ b/src/proxy2vpn/http_client.py
@@ -1,0 +1,117 @@
+"""Asynchronous HTTP client utilities for proxy2vpn."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+import asyncio
+import time
+
+import aiohttp
+
+from .logging_utils import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class HTTPClientError(RuntimeError):
+    """Raised when an HTTP request fails."""
+
+
+@dataclass(slots=True)
+class RetryPolicy:
+    """Configuration for request retries."""
+
+    attempts: int = 3
+    backoff: float = 0.5
+
+
+@dataclass(slots=True)
+class HTTPClientConfig:
+    """Settings for :class:`HTTPClient`."""
+
+    base_url: str
+    timeout: float = 10
+    verify_ssl: bool = True
+    auth: tuple[str, str] | None = None
+    retry: RetryPolicy = field(default_factory=RetryPolicy)
+
+
+class HTTPClient:
+    """Simple wrapper around :class:`aiohttp.ClientSession` with retries."""
+
+    def __init__(self, config: HTTPClientConfig):
+        self._config = config
+        self._session: aiohttp.ClientSession | None = None
+
+    async def __aenter__(self) -> "HTTPClient":
+        await self._ensure_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        await self.close()
+
+    async def _ensure_session(self) -> None:
+        if self._session and not self._session.closed:
+            return
+        timeout = aiohttp.ClientTimeout(total=self._config.timeout)
+        connector = aiohttp.TCPConnector(ssl=self._config.verify_ssl)
+        auth = None
+        if self._config.auth:
+            username, password = self._config.auth
+            auth = aiohttp.BasicAuth(username, password)
+        self._session = aiohttp.ClientSession(
+            base_url=self._config.base_url,
+            timeout=timeout,
+            connector=connector,
+            auth=auth,
+        )
+
+    async def close(self) -> None:
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+    async def request(self, method: str, path: str, **kwargs: Any) -> Any:
+        await self._ensure_session()
+        if not self._session:
+            raise HTTPClientError("session not initialized")
+
+        for attempt in range(1, self._config.retry.attempts + 2):
+            start = time.perf_counter()
+            try:
+                async with self._session.request(method, path, **kwargs) as resp:
+                    resp.raise_for_status()
+                    data = await resp.json(content_type=None)
+                    elapsed = time.perf_counter() - start
+                    logger.info(
+                        "http_request",
+                        extra={
+                            "method": method.upper(),
+                            "path": path,
+                            "status": resp.status,
+                            "elapsed": elapsed,
+                        },
+                    )
+                    return data
+            except aiohttp.ClientError as exc:
+                elapsed = time.perf_counter() - start
+                logger.warning(
+                    "http_request_error",
+                    extra={
+                        "method": method.upper(),
+                        "path": path,
+                        "elapsed": elapsed,
+                        "error": str(exc),
+                        "attempt": attempt,
+                    },
+                )
+                if attempt > self._config.retry.attempts:
+                    raise HTTPClientError(str(exc)) from exc
+                await asyncio.sleep(self._config.retry.backoff * attempt)
+
+    async def get(self, path: str, **kwargs: Any) -> Any:
+        return await self.request("GET", path, **kwargs)
+
+    async def post(self, path: str, **kwargs: Any) -> Any:
+        return await self.request("POST", path, **kwargs)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,68 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+from aiohttp import web
+
+# Ensure src package importable
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from proxy2vpn.http_client import (
+    HTTPClient,
+    HTTPClientConfig,
+    RetryPolicy,
+    HTTPClientError,
+)
+
+
+async def _start_test_server():
+    app = web.Application()
+    state = {"flaky_count": 0}
+
+    async def ok(request):
+        return web.json_response({"ok": True})
+
+    async def flaky(request):
+        if state["flaky_count"] == 0:
+            state["flaky_count"] += 1
+            raise web.HTTPInternalServerError()
+        return web.json_response({"ok": True})
+
+    async def error(request):  # pragma: no cover - simple error path
+        raise web.HTTPInternalServerError()
+
+    app.add_routes(
+        [
+            web.get("/ok", ok),
+            web.get("/flaky", flaky),
+            web.get("/error", error),
+        ]
+    )
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    base_url = f"http://127.0.0.1:{port}"
+    return runner, base_url
+
+
+def test_http_client_handles_requests_and_retries():
+    async def runner():
+        app_runner, base_url = await _start_test_server()
+        cfg = HTTPClientConfig(
+            base_url=base_url, retry=RetryPolicy(attempts=1, backoff=0)
+        )
+        async with HTTPClient(cfg) as client:
+            data = await client.get("/ok")
+            assert data == {"ok": True}
+            # First call fails then succeeds due to retry
+            data = await client.get("/flaky")
+            assert data == {"ok": True}
+            with pytest.raises(HTTPClientError):
+                await client.get("/error")
+        assert client._session is not None and client._session.closed
+        await app_runner.cleanup()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- add HTTPClientConfig dataclass and HTTPClient wrapper around aiohttp
- log request timing metrics and retry failures
- cover HTTP client behavior with unit tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c7d1f0190832f86c172cbdfe4be1e