### PR TITLE
refactor: wrap control client helpers with class interface

### DIFF
--- a/news/control-client-wrappers.misc.md
+++ b/news/control-client-wrappers.misc.md
@@ -1,0 +1,2 @@
+Replace standalone control API helpers with wrappers around ``GluetunControlClient`` and update CLI usage.
+

--- a/src/proxy2vpn/control_client.py
+++ b/src/proxy2vpn/control_client.py
@@ -1,73 +1,43 @@
-"""Client helpers for interacting with the gluetun control API."""
+"""Compatibility wrappers around :class:`GluetunControlClient`."""
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Any
 
-import asyncio
-import aiohttp
-
-from .config import (
-    CONTROL_API_ENDPOINTS,
-    DEFAULT_TIMEOUT,
-    MAX_RETRIES,
-    VERIFY_SSL,
+from .http_client import (
+    GluetunControlClient,
+    HTTPClientError as ControlClientError,
 )
 
-
-class ControlClientError(RuntimeError):
-    """Raised when the control API returns an error."""
-
-
-def _build_url(base_url: str, path: str) -> str:
-    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
-
-
-async def _request(method: str, url: str, action: str, **kwargs: Any) -> Any:
-    timeout = aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT)
-    connector = aiohttp.TCPConnector(ssl=VERIFY_SSL)
-    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
-        for attempt in range(1, MAX_RETRIES + 2):
-            try:
-                async with session.request(method, url, **kwargs) as response:
-                    response.raise_for_status()
-                    return await response.json(content_type=None)
-            except (
-                aiohttp.ClientResponseError
-            ) as exc:  # pragma: no cover - handled for clarity
-                raise ControlClientError(
-                    f"{action}: {exc.status} {exc.message}"
-                ) from exc
-            except aiohttp.ClientError as exc:  # pragma: no cover - network issues
-                if attempt > MAX_RETRIES:
-                    raise ControlClientError(f"{action}: {exc}") from exc
-                await asyncio.sleep(0.5 * attempt)
+__all__ = [
+    "ControlClientError",
+    "get_status",
+    "set_openvpn_status",
+    "get_public_ip",
+    "restart_tunnel",
+]
 
 
 async def get_status(base_url: str) -> dict[str, Any]:
     """Return the current control server status."""
-    url = _build_url(base_url, CONTROL_API_ENDPOINTS["status"])
-    return await _request("get", url, "Failed to get status")
+    async with GluetunControlClient(base_url) as client:
+        return asdict(await client.status())
 
 
 async def set_openvpn_status(base_url: str, status: bool) -> dict[str, Any]:
     """Enable or disable OpenVPN through the control API."""
-    url = _build_url(base_url, CONTROL_API_ENDPOINTS["openvpn"])
-    payload = {"status": status}
-    return await _request("post", url, "Failed to set OpenVPN status", json=payload)
+    async with GluetunControlClient(base_url) as client:
+        return asdict(await client.set_openvpn(status))
 
 
 async def get_public_ip(base_url: str) -> str:
     """Return the public IP reported by the control API."""
-    url = _build_url(base_url, CONTROL_API_ENDPOINTS["ip"])
-    data = await _request("get", url, "Failed to get public IP")
-    if isinstance(data, dict):
-        return data.get("ip", "")
-    return str(data)
+    async with GluetunControlClient(base_url) as client:
+        return (await client.public_ip()).ip
 
 
 async def restart_tunnel(base_url: str) -> dict[str, Any]:
     """Restart the VPN tunnel through the control API."""
-    url = _build_url(base_url, CONTROL_API_ENDPOINTS["openvpn_status"])
-    payload = {"status": "restarted"}
-    return await _request("put", url, "Failed to restart tunnel", json=payload)
+    async with GluetunControlClient(base_url) as client:
+        return asdict(await client.restart_tunnel())

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -11,68 +11,73 @@ BASE_URL = "http://localhost:8000"
 
 
 def test_get_status_calls_correct_url(monkeypatch):
-    called: dict[str, str] = {}
+    called: dict[str, object] = {}
 
     async def fake_request(
-        method, url, action, **kwargs
+        self, method, path, **kwargs
     ):  # pragma: no cover - simple mock
         called["method"] = method
-        called["url"] = url
+        called["path"] = path
         return {"status": "ok"}
 
-    monkeypatch.setattr(control_client, "_request", fake_request)
+    monkeypatch.setattr(control_client.GluetunControlClient, "request", fake_request)
     result = asyncio.run(control_client.get_status(BASE_URL))
     assert result == {"status": "ok"}
-    assert called["method"] == "get"
-    assert called["url"] == f"{BASE_URL}/status"
+    assert called["method"] == "GET"
+    assert called["path"] == control_client.GluetunControlClient.ENDPOINTS["status"]
 
 
 def test_set_openvpn_status_posts_payload(monkeypatch):
     called: dict[str, object] = {}
 
     async def fake_request(
-        method, url, action, **kwargs
+        self, method, path, **kwargs
     ):  # pragma: no cover - simple mock
         called["method"] = method
-        called["url"] = url
+        called["path"] = path
         called["json"] = kwargs.get("json")
         return {"status": kwargs["json"]["status"]}
 
-    monkeypatch.setattr(control_client, "_request", fake_request)
+    monkeypatch.setattr(control_client.GluetunControlClient, "request", fake_request)
     result = asyncio.run(control_client.set_openvpn_status(BASE_URL, True))
     assert result == {"status": True}
-    assert called["method"] == "post"
-    assert called["url"] == f"{BASE_URL}/openvpn"
+    assert called["method"] == "POST"
+    assert called["path"] == control_client.GluetunControlClient.ENDPOINTS["openvpn"]
     assert called["json"] == {"status": True}
 
 
 def test_get_public_ip_returns_ip(monkeypatch):
-    called: dict[str, str] = {}
+    called: dict[str, object] = {}
 
     async def fake_request(
-        method, url, action, **kwargs
+        self, method, path, **kwargs
     ):  # pragma: no cover - simple mock
-        called["url"] = url
+        called["path"] = path
         return {"ip": "1.2.3.4"}
 
-    monkeypatch.setattr(control_client, "_request", fake_request)
+    monkeypatch.setattr(control_client.GluetunControlClient, "request", fake_request)
     ip = asyncio.run(control_client.get_public_ip(BASE_URL))
     assert ip == "1.2.3.4"
-    assert called["url"] == f"{BASE_URL}/ip"
+    assert called["path"] == control_client.GluetunControlClient.ENDPOINTS["ip"]
 
 
 def test_restart_tunnel_puts_status(monkeypatch):
     called: dict[str, object] = {}
 
-    async def fake_request(method, url, action, **kwargs):
+    async def fake_request(
+        self, method, path, **kwargs
+    ):  # pragma: no cover - simple mock
         called["method"] = method
-        called["url"] = url
+        called["path"] = path
         called["json"] = kwargs.get("json")
         return {"status": "restarted"}
 
-    monkeypatch.setattr(control_client, "_request", fake_request)
+    monkeypatch.setattr(control_client.GluetunControlClient, "request", fake_request)
     result = asyncio.run(control_client.restart_tunnel(BASE_URL))
     assert result == {"status": "restarted"}
-    assert called["method"] == "put"
-    assert called["url"] == f"{BASE_URL}/openvpn/status"
+    assert called["method"] == "PUT"
+    assert (
+        called["path"]
+        == control_client.GluetunControlClient.ENDPOINTS["openvpn_status"]
+    )
     assert called["json"] == {"status": "restarted"}


### PR DESCRIPTION
## Summary
- refactor control client helpers to instantiate `GluetunControlClient`
- use `GluetunControlClient` directly in CLI VPN commands
- update tests to patch `GluetunControlClient.request`

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c8442a434832fbad8245dbfbe06d7