### PR TITLE
refactor: use HTTPClient for server list retrieval

### DIFF
--- a/news/server-manager-httpclient.refactor.md
+++ b/news/server-manager-httpclient.refactor.md
@@ -1,0 +1,1 @@
+Use centralized HTTPClient for server list downloads with sync and async support.


### PR DESCRIPTION
## Summary
- replace direct HTTP requests in server manager with shared HTTPClient
- support cached server list fetching in sync and async contexts
- mock HTTPClient in server manager tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c845a75c4832f91cf3903c244a695