### PR TITLE
refactor: use HTTPClient for IP lookup

### DIFF
--- a/news/ip-utils-http-client.feature.md
+++ b/news/ip-utils-http-client.feature.md
@@ -1,0 +1,1 @@
+IP address lookup now uses a shared HTTPClient with retries.

--- a/tests/test_ip_utils.py
+++ b/tests/test_ip_utils.py
@@ -1,5 +1,8 @@
+import asyncio
 import pathlib
 import sys
+
+from aiohttp import web
 
 # Ensure src package is importable
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
@@ -14,3 +17,60 @@ def test_parse_ip_from_html():
 
 def test_parse_ip_invalid_text():
     assert ip_utils._parse_ip("<html></html>") == ""
+
+
+async def _start_ip_server():
+    app = web.Application()
+    state = {"flaky": 0}
+
+    async def fast(request):
+        return web.Response(text="203.0.113.5")
+
+    async def slow(request):
+        await asyncio.sleep(0.1)
+        return web.Response(text="203.0.113.6")
+
+    async def flaky(request):
+        if state["flaky"] == 0:
+            state["flaky"] += 1
+            raise web.HTTPInternalServerError()
+        return web.Response(text="203.0.113.7")
+
+    app.add_routes(
+        [
+            web.get("/fast", fast),
+            web.get("/slow", slow),
+            web.get("/flaky", flaky),
+        ]
+    )
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    base = f"http://127.0.0.1:{port}"
+    return runner, base
+
+
+def test_fetch_ip_async_returns_first_result(monkeypatch):
+    async def runner():
+        app_runner, base_url = await _start_ip_server()
+        monkeypatch.setattr(
+            ip_utils, "IP_SERVICES", (f"{base_url}/slow", f"{base_url}/fast")
+        )
+        ip = await ip_utils.fetch_ip_async()
+        assert ip == "203.0.113.5"
+        await app_runner.cleanup()
+
+    asyncio.run(runner())
+
+
+def test_fetch_ip_async_retries(monkeypatch):
+    async def runner():
+        app_runner, base_url = await _start_ip_server()
+        monkeypatch.setattr(ip_utils, "IP_SERVICES", (f"{base_url}/flaky",))
+        ip = await ip_utils.fetch_ip_async()
+        assert ip == "203.0.113.7"
+        await app_runner.cleanup()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- reuse HTTPClient session for fetching public IP
- add text request helper to HTTPClient
- test IP lookups concurrently with retries

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c845b9538832fa638860b715652e6