### PR TITLE
feat: proxy health checks via async HTTP client

### DIFF
--- a/news/server-monitor-http-client.feature.md
+++ b/news/server-monitor-http-client.feature.md
@@ -1,0 +1,1 @@
+ServerMonitor now uses an injected HTTPClient for proxy health checks with timing metrics.


### PR DESCRIPTION
## Summary
- inject HTTPClient into ServerMonitor and use it for proxy health checks
- measure proxy response times using async HTTPClient calls
- mock HTTPClient in server monitor tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c845f534c832f9a496daf2d5808bc