### PR TITLE
feat: add force option to fleet deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ For enterprise-scale deployment across multiple cities and VPN accounts:
 
 ### Fleet management
 - `proxy2vpn fleet plan --countries "Germany,France" --profiles "acc1:2,acc2:8" [--output PLAN_FILE] [--unique-ips]`
-- `proxy2vpn fleet deploy [--plan-file PLAN_FILE] [--parallel] [--validate-first] [--dry-run]`
+- `proxy2vpn fleet deploy [--plan-file PLAN_FILE] [--parallel] [--validate-first] [--dry-run] [--force]`
 - `proxy2vpn fleet status [--format table|json|yaml] [--show-allocation] [--show-health]`
 - `proxy2vpn fleet rotate [--country COUNTRY] [--criteria random|performance|load] [--dry-run]`
 - `proxy2vpn fleet scale up|down [--countries COUNTRIES] [--factor N]`

--- a/news/121.feature.md
+++ b/news/121.feature.md
@@ -1,0 +1,1 @@
+Replace --recreate-network flag in `fleet deploy` with `--force` to rebuild containers and network.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -999,14 +999,17 @@ def fleet_deploy_cmd(
         True, help="Validate servers before deployment"
     ),
     dry_run: bool = typer.Option(False, help="Show what would be deployed"),
-    recreate_network: bool = typer.Option(
-        False, help="Recreate Docker network if it already exists"
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Recreate containers and Docker network if they exist",
     ),
 ):
     """Deploy VPN fleet from plan file"""
     from .fleet_commands import fleet_deploy
 
-    fleet_deploy(ctx, plan_file, parallel, validate_first, dry_run, recreate_network)
+    fleet_deploy(ctx, plan_file, parallel, validate_first, dry_run, force)
 
 
 @fleet_app.command("status")

--- a/src/proxy2vpn/fleet_commands.py
+++ b/src/proxy2vpn/fleet_commands.py
@@ -106,8 +106,11 @@ def fleet_deploy(
         True, help="Validate servers before deployment"
     ),
     dry_run: bool = typer.Option(False, help="Show what would be deployed"),
-    recreate_network: bool = typer.Option(
-        False, help="Recreate Docker network if it already exists"
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Recreate containers and Docker network if they exist",
     ),
 ):
     """Deploy VPN fleet from plan file"""
@@ -141,7 +144,7 @@ def fleet_deploy(
                 plan,
                 validate_servers=validate_first,
                 parallel=parallel,
-                recreate_network=recreate_network,
+                force=force,
             )
         )
 

--- a/src/proxy2vpn/fleet_manager.py
+++ b/src/proxy2vpn/fleet_manager.py
@@ -289,7 +289,7 @@ class FleetManager:
         plan: DeploymentPlan,
         validate_servers: bool = True,
         parallel: bool = True,
-        recreate_network: bool = False,
+        force: bool = False,
     ) -> DeploymentResult:
         """Execute bulk deployment with server validation"""
 
@@ -324,7 +324,7 @@ class FleetManager:
         added_services: List[str] = []
 
         try:
-            await asyncio.to_thread(ensure_network, recreate_network)
+            await asyncio.to_thread(ensure_network, force)
             # Create services in compose file
             for service_plan in plan.services:
                 # Create Docker labels for service identification and metadata
@@ -360,9 +360,9 @@ class FleetManager:
 
             # Start containers
             if parallel:
-                await self._start_services_parallel(added_services)
+                await self._start_services_parallel(added_services, force)
             else:
-                await self._start_services_sequential(added_services)
+                await self._start_services_sequential(added_services, force)
 
             deployed = len(added_services)
 
@@ -405,9 +405,14 @@ class FleetManager:
             deployed=deployed, failed=failed, services=plan.service_names, errors=errors
         )
 
-    async def _start_services_parallel(self, service_names: List[str]):
+    async def _start_services_parallel(self, service_names: List[str], force: bool):
         """Start services in parallel with limited concurrency"""
-        from .docker_ops import recreate_vpn_container, start_container
+        from docker.errors import NotFound
+        from .docker_ops import (
+            create_vpn_container,
+            recreate_vpn_container,
+            start_container,
+        )
 
         semaphore = asyncio.Semaphore(5)  # Max 5 concurrent starts
 
@@ -421,8 +426,19 @@ class FleetManager:
                     profile = self.compose_manager.get_profile(service.profile)
 
                     # Create and start container
-                    await asyncio.to_thread(recreate_vpn_container, service, profile)
-                    await asyncio.to_thread(start_container, service_name)
+                    if force:
+                        await asyncio.to_thread(
+                            recreate_vpn_container, service, profile
+                        )
+                        await asyncio.to_thread(start_container, service_name)
+                    else:
+                        try:
+                            await asyncio.to_thread(start_container, service_name)
+                        except NotFound:
+                            await asyncio.to_thread(
+                                create_vpn_container, service, profile
+                            )
+                            await asyncio.to_thread(start_container, service_name)
 
                     console.print(f"[green]✅[/green] Started {service_name}")
 
@@ -434,9 +450,14 @@ class FleetManager:
         tasks = [start_service(name) for name in service_names]
         await asyncio.gather(*tasks)
 
-    async def _start_services_sequential(self, service_names: List[str]):
+    async def _start_services_sequential(self, service_names: List[str], force: bool):
         """Start services one by one"""
-        from .docker_ops import recreate_vpn_container, start_container
+        from docker.errors import NotFound
+        from .docker_ops import (
+            create_vpn_container,
+            recreate_vpn_container,
+            start_container,
+        )
 
         for service_name in service_names:
             try:
@@ -447,8 +468,15 @@ class FleetManager:
                 profile = self.compose_manager.get_profile(service.profile)
 
                 # Create and start container
-                await asyncio.to_thread(recreate_vpn_container, service, profile)
-                await asyncio.to_thread(start_container, service_name)
+                if force:
+                    await asyncio.to_thread(recreate_vpn_container, service, profile)
+                    await asyncio.to_thread(start_container, service_name)
+                else:
+                    try:
+                        await asyncio.to_thread(start_container, service_name)
+                    except NotFound:
+                        await asyncio.to_thread(create_vpn_container, service, profile)
+                        await asyncio.to_thread(start_container, service_name)
 
                 console.print(f"[green]✅[/green] Started {service_name}")
 

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -167,7 +167,7 @@ def test_deploy_fleet_rolls_back_on_error(monkeypatch, fleet_manager, capsys):
     )
     monkeypatch.setattr("proxy2vpn.fleet_manager.stop_container", fake_stop)
     monkeypatch.setattr("proxy2vpn.fleet_manager.remove_container", fake_remove)
-    monkeypatch.setattr("proxy2vpn.fleet_manager.ensure_network", lambda recreate: None)
+    monkeypatch.setattr("proxy2vpn.fleet_manager.ensure_network", lambda force: None)
 
     result = asyncio.run(
         fleet_manager.deploy_fleet(plan, validate_servers=False, parallel=False)
@@ -218,12 +218,12 @@ def test_deploy_fleet_skips_invalid_locations(monkeypatch, fleet_manager, capsys
     def fake_add_service(service):
         added.append(service.name)
 
-    async def fake_start(service_names):
+    async def fake_start(service_names, force):
         start_calls.extend(service_names)
 
     monkeypatch.setattr(fleet_manager.compose_manager, "add_service", fake_add_service)
     monkeypatch.setattr(fleet_manager, "_start_services_sequential", fake_start)
-    monkeypatch.setattr("proxy2vpn.fleet_manager.ensure_network", lambda recreate: None)
+    monkeypatch.setattr("proxy2vpn.fleet_manager.ensure_network", lambda force: None)
 
     result = asyncio.run(
         fleet_manager.deploy_fleet(plan, validate_servers=True, parallel=False)
@@ -278,7 +278,7 @@ def test_start_services_sequential_passes_service_name(monkeypatch, tmp_path):
     monkeypatch.setattr("proxy2vpn.docker_ops.start_container", fake_start)
     monkeypatch.setattr("proxy2vpn.docker_ops.recreate_vpn_container", fake_recreate)
 
-    asyncio.run(fm._start_services_sequential([svc.name]))
+    asyncio.run(fm._start_services_sequential([svc.name], True))
 
     assert start_calls == [svc.name]
 


### PR DESCRIPTION
## Summary
- replace `--recreate-network` with `--force` flag for `fleet deploy`
- allow `--force` to recreate containers and Docker network
- document new flag and update tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689c9697f118832fa67893d834c58a98