### PR TITLE
feat: add provider column to vpn list

### DIFF
--- a/news/143.feature.md
+++ b/news/143.feature.md
@@ -1,0 +1,1 @@
+Add provider column to `vpn list` output.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -345,6 +345,7 @@ async def vpn_list(
     table.add_column("N", style="dim blue")
     table.add_column("Name", style="green")
     table.add_column("Port")
+    table.add_column("Provider")
     table.add_column("Profile")
     table.add_column("Location")
     table.add_column("Status")
@@ -370,6 +371,7 @@ async def vpn_list(
             str(i),
             svc.name,
             str(svc.port),
+            svc.provider,
             svc.profile,
             svc.location,
             f"[{status_style}]{status}[/{status_style}]",

--- a/tests/test_cli_vpn_list.py
+++ b/tests/test_cli_vpn_list.py
@@ -35,7 +35,7 @@ def test_vpn_list_ips_only_async(monkeypatch):
     assert called["n"] == 1
 
 
-def test_vpn_list_includes_location(monkeypatch):
+def test_vpn_list_includes_provider_and_location(monkeypatch):
     runner = CliRunner()
 
     svc = VPNService(
@@ -71,5 +71,7 @@ def test_vpn_list_includes_location(monkeypatch):
 
     result = runner.invoke(cli.app, ["vpn", "list"])
     assert result.exit_code == 0
+    assert "Provider" in result.stdout
+    assert "prov" in result.stdout
     assert "Location" in result.stdout
     assert "US" in result.stdout


### PR DESCRIPTION
## Summary
- show each VPN's provider in `vpn list` output
- test `vpn list` output to include provider info

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cb521f46c832f9ca4a000e7271508