### PR TITLE
fix: publish control ports for fleet deployments

### DIFF
--- a/news/155.bugfix.md
+++ b/news/155.bugfix.md
@@ -1,0 +1,1 @@
+Ensure fleet deployments publish control ports and labels for VPN services so control commands work.

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -40,7 +40,7 @@ def test_plan_deployment_basic_allocation(fleet_manager, monkeypatch):
         "prov-b-city2",
     ]
     assert [s.profile for s in plan.services] == ["acc1", "acc2"]
-    assert [s.port for s in plan.services] == [30000, 30001]
+    assert [s.port for s in plan.services] == [30000, 30002]
 
 
 def test_plan_deployment_sanitizes_and_limits(fleet_manager, monkeypatch):
@@ -234,6 +234,8 @@ def test_deploy_fleet_skips_invalid_locations(monkeypatch, fleet_manager, capsys
 
     def fake_add_service(service):
         added.append(service.name)
+        assert service.control_port != 0
+        assert service.labels.get("vpn.control_port") == str(service.control_port)
 
     async def fake_start(service_names, force):
         start_calls.extend(service_names)


### PR DESCRIPTION
## Summary
- allocate service ports with gaps for control ports during fleet planning
- assign and label control ports when creating services
- test fleet deploy ensures control port labels

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cf53075f8832fa1fb99638ab53908