### PR TITLE
fix: bind proxy ports to 0.0.0.0 in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ services:
   vpn1:
     image: qmcgaw/gluetun
     ports:
-      - "8888:8888/tcp"    # proxy port
+      - "0.0.0.0:8888:8888/tcp"    # proxy port
     labels:
       vpn.type: vpn
       vpn.port: "8888"

--- a/news/155.bugfix.md
+++ b/news/155.bugfix.md
@@ -1,0 +1,2 @@
+Bind proxy ports to 0.0.0.0 in generated compose files so proxies are reachable externally; control ports remain unchanged.
+

--- a/src/proxy2vpn/compose_manager.py
+++ b/src/proxy2vpn/compose_manager.py
@@ -8,6 +8,7 @@ import shutil
 from filelock import FileLock
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap, merge_attrib
+from ruamel.yaml.mergevalue import MergeValue
 
 from .models import Profile, VPNService
 from .compose_validator import validate_compose
@@ -103,7 +104,11 @@ class ComposeManager:
         if profile_map is None:
             raise KeyError(f"Profile '{service.profile}' not found")
         svc_map = CommentedMap(service.to_compose_service())
-        setattr(svc_map, merge_attrib, [(0, profile_map)])
+        merge_val = MergeValue()
+        merge_val.value = [profile_map]
+        merge_val.merge_pos = 0
+        merge_val.sequence = None
+        setattr(svc_map, merge_attrib, merge_val)
         services[service.name] = svc_map
         self.save()
 
@@ -128,7 +133,11 @@ class ComposeManager:
 
         # Update service configuration
         svc_map = CommentedMap(service.to_compose_service())
-        setattr(svc_map, merge_attrib, [(0, profile_map)])  # YAML merge
+        merge_val = MergeValue()
+        merge_val.value = [profile_map]
+        merge_val.merge_pos = 0
+        merge_val.sequence = None
+        setattr(svc_map, merge_attrib, merge_val)  # YAML merge
         services[service.name] = svc_map
         self.save()
 

--- a/src/proxy2vpn/models.py
+++ b/src/proxy2vpn/models.py
@@ -61,7 +61,7 @@ class VPNService:
 
     def to_compose_service(self) -> dict:
         env_list = [f"{k}={v}" for k, v in self.environment.items()]
-        ports = [f"{self.port}:8888/tcp"]
+        ports = [f"0.0.0.0:{self.port}:8888/tcp"]
         labels = dict(self.labels)
         labels.setdefault("vpn.port", str(self.port))
         service = {

--- a/tests/test_compose_manager.py
+++ b/tests/test_compose_manager.py
@@ -97,6 +97,7 @@ def test_add_service_after_init(tmp_path):
     manager.add_service(service)
     compose_text = compose_path.read_text()
     assert "<<: *vpn-base-andr" in compose_text
+    assert "0.0.0.0:12345:8888/tcp" in compose_text
 
 
 def test_recover_from_corruption(tmp_path):


### PR DESCRIPTION
## Summary
- expose proxy ports on all interfaces in generated compose files
- keep profile anchors intact when adding or updating services
- document and test new 0.0.0.0 port mapping

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68ac0baea4d0832fab2af9f7e1f8f8f5