### PR TITLE
feat: validate VPN service locations

### DIFF
--- a/news/200.feature.md
+++ b/news/200.feature.md
@@ -1,0 +1,1 @@
+Add location validation for VPN CLI commands. Locations can be city, country, or city,country and validation can be bypassed with --force.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -244,6 +244,20 @@ def profile_apply(
 # ---------------------------------------------------------------------------
 
 
+def _validate_service_locations(services: list[VPNService], force: bool) -> None:
+    if force:
+        return
+    mgr = ServerManager()
+    for svc in services:
+        loc = getattr(svc, "location", "")
+        provider = getattr(svc, "provider", "")
+        if loc and not mgr.validate_location(provider, loc):
+            abort(
+                f"Invalid location '{loc}' for {provider}",
+                "Use --force to override",
+            )
+
+
 @vpn_app.command("create")
 def vpn_create(
     ctx: typer.Context,
@@ -256,6 +270,9 @@ def vpn_create(
     ),
     provider: str = typer.Option(config.DEFAULT_PROVIDER),
     location: str = typer.Option("", help="Optional location, e.g. city"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Ignore location validation"
+    ),
 ):
     """Create a VPN service entry in the compose file."""
 
@@ -274,7 +291,17 @@ def vpn_create(
     env = {"VPN_SERVICE_PROVIDER": provider}
     location = location.strip()
     if location:
-        env["SERVER_CITIES"] = location
+        mgr = ServerManager()
+        if not force and not mgr.validate_location(provider, location):
+            abort(
+                f"Invalid location '{location}' for {provider}",
+                "Use --force to override",
+            )
+        city, country = mgr.parse_location(provider, location)
+        if city:
+            env["SERVER_CITIES"] = city
+        if country:
+            env["SERVER_COUNTRIES"] = country
     labels = {
         "vpn.type": "vpn",
         "vpn.port": str(port),
@@ -396,6 +423,9 @@ def vpn_start(
         None, callback=lambda v: sanitize_name(v) if v else None
     ),
     all: bool = typer.Option(False, "--all", help="Start all VPN services"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Ignore location validation"
+    ),
 ):
     """Start one or all VPN containers."""
 
@@ -404,6 +434,8 @@ def vpn_start(
     if all and name is not None:
         abort("Cannot specify NAME when using --all")
     if all:
+        services = manager.list_services()
+        _validate_service_locations(services, force)
         from .docker_ops import start_all_vpn_containers
 
         results = start_all_vpn_containers(manager)
@@ -420,6 +452,7 @@ def vpn_start(
     except KeyError:
         abort(f"Service '{name}' not found")
     assert svc is not None  # Type narrowing after successful assignment
+    _validate_service_locations([svc], force)
 
     from .docker_ops import (
         start_container,
@@ -498,6 +531,9 @@ def vpn_restart(
         None, callback=lambda v: sanitize_name(v) if v else None
     ),
     all: bool = typer.Option(False, "--all", help="Restart all VPN services"),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Ignore location validation"
+    ),
 ):
     """Restart one or all VPN containers."""
 
@@ -506,9 +542,10 @@ def vpn_restart(
     if all and name is not None:
         abort("Cannot specify NAME when using --all")
     if all:
+        services = manager.list_services()
+        _validate_service_locations(services, force)
         from .docker_ops import recreate_vpn_container, start_container
 
-        services = manager.list_services()
         for svc in services:
             profile = manager.get_profile(svc.profile)
             try:
@@ -530,6 +567,7 @@ def vpn_restart(
     except KeyError:
         abort(f"Service '{name}' not found")
     assert svc is not None  # Type narrowing after successful assignment
+    _validate_service_locations([svc], force)
 
     from .docker_ops import (
         recreate_vpn_container,

--- a/src/proxy2vpn/server_manager.py
+++ b/src/proxy2vpn/server_manager.py
@@ -107,12 +107,40 @@ class ServerManager:
         }
         return sorted(cities)
 
-    def validate_location(self, provider: str, location: str) -> bool:
-        """Return ``True`` if LOCATION exists for PROVIDER."""
+    def parse_location(
+        self, provider: str, location: str
+    ) -> tuple[str | None, str | None]:
+        """Split LOCATION into city and/or country components."""
 
         data = self.data or self.update_servers()
         prov = data.get(provider, {})
         servers = prov.get("servers", [])
+        loc = location.strip()
+        if "," in loc:
+            city, country = [part.strip() for part in loc.split(",", 1)]
+            return city, country
+        loc_l = loc.lower()
+        for srv in servers:
+            if srv.get("city", "").lower() == loc_l:
+                return loc, None
+            if srv.get("country", "").lower() == loc_l:
+                return None, loc
+        return loc, None
+
+    def validate_location(self, provider: str, location: str) -> bool:
+        """Return ``True`` if LOCATION exists for PROVIDER."""
+        data = self.data or self.update_servers()
+        prov = data.get(provider, {})
+        servers = prov.get("servers", [])
+        if "," in location:
+            city, country = [part.strip().lower() for part in location.split(",", 1)]
+            for srv in servers:
+                if (
+                    srv.get("city", "").lower() == city
+                    and srv.get("country", "").lower() == country
+                ):
+                    return True
+            return False
         loc = location.lower()
         for srv in servers:
             if (

--- a/tests/test_cli_location_validation.py
+++ b/tests/test_cli_location_validation.py
@@ -1,0 +1,150 @@
+import pathlib
+from typer.testing import CliRunner
+
+from proxy2vpn import cli
+from proxy2vpn.compose_manager import ComposeManager
+
+
+def _copy_compose(tmp_path: pathlib.Path) -> pathlib.Path:
+    src = pathlib.Path(__file__).parent / "test_compose.yml"
+    env_path = tmp_path / "env.test"
+    env_path.write_text("KEY=value\n")
+    dest = tmp_path / "compose.yml"
+    text = src.read_text().replace("env.test", str(env_path))
+    dest.write_text(text)
+    return dest
+
+
+def test_vpn_create_location_validation(tmp_path, monkeypatch):
+    compose_path = _copy_compose(tmp_path)
+    runner = CliRunner()
+
+    class DummyServerManager:
+        def validate_location(self, provider, location):
+            return location in {"Toronto", "CA", "Toronto,CA"}
+
+        def parse_location(self, provider, location):
+            if "," in location:
+                city, country = location.split(",", 1)
+                return city, country
+            if location == "Toronto":
+                return location, None
+            return None, location
+
+    monkeypatch.setattr(cli, "ServerManager", lambda: DummyServerManager())
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "--compose-file",
+            str(compose_path),
+            "vpn",
+            "create",
+            "vpn3",
+            "test",
+            "--port",
+            "7777",
+            "--provider",
+            "prov",
+            "--location",
+            "Toronto,CA",
+        ],
+    )
+    assert result.exit_code == 0
+
+    manager = ComposeManager(compose_path)
+    svc = manager.get_service("vpn3")
+    assert svc.environment["SERVER_CITIES"] == "Toronto"
+    assert svc.environment["SERVER_COUNTRIES"] == "CA"
+
+    class FailingServerManager:
+        def validate_location(self, provider, location):
+            return False
+
+        def parse_location(self, provider, location):
+            return location, None
+
+    monkeypatch.setattr(cli, "ServerManager", lambda: FailingServerManager())
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "--compose-file",
+            str(compose_path),
+            "vpn",
+            "create",
+            "vpn4",
+            "test",
+            "--port",
+            "7778",
+            "--provider",
+            "prov",
+            "--location",
+            "Atlantis",
+        ],
+    )
+    assert result.exit_code != 0
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "--compose-file",
+            str(compose_path),
+            "vpn",
+            "create",
+            "vpn4",
+            "test",
+            "--port",
+            "7778",
+            "--provider",
+            "prov",
+            "--location",
+            "Atlantis",
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_vpn_start_requires_valid_location(tmp_path, monkeypatch):
+    compose_path = _copy_compose(tmp_path)
+    runner = CliRunner()
+
+    class DummyServerManager:
+        def validate_location(self, provider, location):
+            return False
+
+        def parse_location(self, provider, location):
+            return location, None
+
+    monkeypatch.setattr(cli, "ServerManager", lambda: DummyServerManager())
+    from proxy2vpn import docker_ops
+
+    monkeypatch.setattr(docker_ops, "recreate_vpn_container", lambda *a, **k: None)
+    monkeypatch.setattr(docker_ops, "start_container", lambda *a, **k: None)
+    monkeypatch.setattr(docker_ops, "analyze_container_logs", lambda *a, **k: [])
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "--compose-file",
+            str(compose_path),
+            "vpn",
+            "start",
+            "testvpn1",
+        ],
+    )
+    assert result.exit_code != 0
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "--compose-file",
+            str(compose_path),
+            "vpn",
+            "start",
+            "testvpn1",
+            "--force",
+        ],
+    )
+    assert result.exit_code == 0

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -64,4 +64,10 @@ def test_location_helpers():
     assert mgr.list_countries("prov") == ["CA", "US"]
     assert mgr.list_cities("prov", "US") == ["Los Angeles", "New York"]
     assert mgr.validate_location("prov", "Toronto")
+    assert mgr.validate_location("prov", "CA")
+    assert mgr.validate_location("prov", "Toronto,CA")
     assert not mgr.validate_location("prov", "Paris")
+    assert not mgr.validate_location("prov", "Paris,FR")
+    assert mgr.parse_location("prov", "Toronto") == ("Toronto", None)
+    assert mgr.parse_location("prov", "CA") == (None, "CA")
+    assert mgr.parse_location("prov", "Toronto,CA") == ("Toronto", "CA")


### PR DESCRIPTION
## Summary
- validate provided locations against cached server list when creating or starting services
- support City, Country, and City,Country formats and set SERVER_CITIES/SERVER_COUNTRIES accordingly
- allow bypassing validation with `--force`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac22d12d74832fb54c6e699ef4d747