### PR TITLE
feat: validate city and country in compose

### DIFF
--- a/news/201.feature.md
+++ b/news/201.feature.md
@@ -1,0 +1,1 @@
+Validate city and country values in compose.yml using the server list.

--- a/src/proxy2vpn/compose_validator.py
+++ b/src/proxy2vpn/compose_validator.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml.nodes import MappingNode, ScalarNode
 
+from .server_manager import ServerManager
+
 
 class ValidationError(Exception):
     """Raised when validation of a compose file fails."""
@@ -26,7 +28,9 @@ def _parse_yaml(path: Path):
     return data, node
 
 
-def validate_compose(path: Path) -> list[str]:
+def validate_compose(
+    path: Path, server_manager: ServerManager | None = None
+) -> list[str]:
     """Validate a docker compose file and return a list of errors."""
 
     errors: list[str] = []
@@ -34,6 +38,13 @@ def validate_compose(path: Path) -> list[str]:
         data, node = _parse_yaml(path)
     except Exception as exc:  # pragma: no cover - error path
         return [f"YAML syntax error: {exc}"]
+
+    if server_manager is None:
+        try:
+            server_manager = ServerManager()
+            server_manager.update_servers()
+        except Exception:  # pragma: no cover - best effort
+            server_manager = None
 
     # Top level keys
     for key in REQUIRED_TOP_LEVEL_KEYS:
@@ -109,6 +120,7 @@ def validate_compose(path: Path) -> list[str]:
             for label in LABEL_REQUIRED_FIELDS:
                 if label not in labels:
                     errors.append(f"Service '{svc_name}' missing label '{label}'")
+
             # port mappings and duplicates
             for p in svc_data.get("ports", []) or []:
                 try:
@@ -137,6 +149,37 @@ def validate_compose(path: Path) -> list[str]:
                     )
                 else:
                     ports_seen[host_port] = svc_name
+
+            if server_manager is not None:
+                env_dict: dict[str, str] = {}
+                env_entries = svc_data.get("environment", []) or []
+                if isinstance(env_entries, dict):
+                    env_dict = {str(k): str(v) for k, v in env_entries.items()}
+                else:
+                    for item in env_entries:
+                        if isinstance(item, str) and "=" in item:
+                            k, v = item.split("=", 1)
+                            env_dict[k] = v
+                provider = labels.get("vpn.provider") or env_dict.get(
+                    "VPN_SERVICE_PROVIDER"
+                )
+                city = env_dict.get("SERVER_CITIES")
+                country = env_dict.get("SERVER_COUNTRIES")
+                location = None
+                if city and country:
+                    location = f"{city},{country}"
+                elif city:
+                    location = city
+                elif country:
+                    location = country
+                if (
+                    location
+                    and provider
+                    and not server_manager.validate_location(provider, location)
+                ):
+                    errors.append(
+                        f"Service '{svc_name}' invalid location '{location}' for {provider}"
+                    )
 
     # Orphaned profiles
     for name in profiles:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+from proxy2vpn import compose_validator
+
+
+class _AlwaysValidServerManager:
+    def update_servers(self):
+        self.data = {}
+        return self.data
+
+    def validate_location(self, provider, location):
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _patch_server_manager(monkeypatch):
+    monkeypatch.setattr(
+        compose_validator, "ServerManager", lambda: _AlwaysValidServerManager()
+    )

--- a/tests/test_compose_validator.py
+++ b/tests/test_compose_validator.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
+from proxy2vpn import compose_validator
 from proxy2vpn.compose_validator import validate_compose
 
 
@@ -133,3 +134,70 @@ def test_missing_profile_field(tmp_path):
     )
     errors = validate_compose(compose)
     assert any("missing field 'image'" in e for e in errors)
+
+
+def test_location_validation(tmp_path, monkeypatch):
+    env = _env(tmp_path)
+    compose = tmp_path / "compose.yml"
+    compose.write_text(
+        dedent(
+            f"""
+            x-vpn-base-test: &vpn-base-test
+              image: gluetun
+              cap_add: [NET_ADMIN]
+              devices: [/dev/net/tun]
+              env_file: {env}
+            services:
+              svc:
+                <<: *vpn-base-test
+                ports: ["20000:1194/tcp"]
+                environment:
+                  - VPN_SERVICE_PROVIDER=prov
+                  - SERVER_CITIES=Toronto
+                  - SERVER_COUNTRIES=CA
+                labels:
+                  vpn.type: vpn
+                  vpn.port: "20000"
+                  vpn.profile: test
+            """
+        )
+    )
+
+    class DummyServerManager:
+        def update_servers(self):
+            self.data = {}
+            return self.data
+
+        def validate_location(self, provider, location):
+            return location in {"Toronto", "CA", "Toronto,CA"}
+
+    monkeypatch.setattr(
+        compose_validator, "ServerManager", lambda: DummyServerManager()
+    )
+    assert validate_compose(compose) == []
+
+    compose.write_text(
+        dedent(
+            f"""
+            x-vpn-base-test: &vpn-base-test
+              image: gluetun
+              cap_add: [NET_ADMIN]
+              devices: [/dev/net/tun]
+              env_file: {env}
+            services:
+              svc:
+                <<: *vpn-base-test
+                ports: ["20000:1194/tcp"]
+                environment:
+                  - VPN_SERVICE_PROVIDER=prov
+                  - SERVER_CITIES=Atlantis
+                  - SERVER_COUNTRIES=CA
+                labels:
+                  vpn.type: vpn
+                  vpn.port: "20000"
+                  vpn.profile: test
+            """
+        )
+    )
+    errors = validate_compose(compose)
+    assert any("invalid location" in e for e in errors)


### PR DESCRIPTION
## Summary
- validate SERVER_CITIES and SERVER_COUNTRIES using server list
- cover compose validation for invalid locations

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2a4b9e38832f814d8def52fae9a8