### PR TITLE
fix: retain anchors for all profiles

### DIFF
--- a/news/202.bugfix.md
+++ b/news/202.bugfix.md
@@ -1,0 +1,1 @@
+Ensure profiles retain their named anchors when added sequentially.

--- a/src/proxy2vpn/compose_manager.py
+++ b/src/proxy2vpn/compose_manager.py
@@ -52,6 +52,13 @@ class ComposeManager:
                         data = CommentedMap(data)
                 # basic validation: ensure YAML structure can be parsed
                 validate_compose(self.compose_path)
+                # Reapply anchors to profiles so they're preserved on save
+                for key, value in data.items():
+                    if key.startswith("x-vpn-base-") and isinstance(
+                        value, CommentedMap
+                    ):
+                        name = key[len("x-vpn-base-") :]
+                        value.yaml_set_anchor(f"vpn-base-{name}", always_dump=True)
                 return data
             except Exception:
                 if backup_path.exists():

--- a/tests/test_compose_manager.py
+++ b/tests/test_compose_manager.py
@@ -107,3 +107,16 @@ def test_recover_from_corruption(tmp_path):
     compose_path.write_text("not: [valid")
     recovered = ComposeManager(compose_path)
     assert recovered.config["health_check_interval"] == "5"
+
+
+def test_multiple_profile_anchors(tmp_path):
+    compose_path = tmp_path / "compose.yml"
+    ComposeManager.create_initial_compose(compose_path, force=True)
+    for name in ["a", "s", "v"]:
+        manager = ComposeManager(compose_path)
+        env = tmp_path / f"env.{name}"
+        env.write_text("KEY=value\n")
+        manager.add_profile(Profile(name=name, env_file=str(env)))
+    text = compose_path.read_text()
+    for name in ["a", "s", "v"]:
+        assert f"x-vpn-base-{name}: &vpn-base-{name}" in text


### PR DESCRIPTION
## Summary
- ensure all VPN profiles keep their named YAML anchors when compose file is reloaded
- cover multiple profile additions with regression test

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac2e8ff048832fb96b94a128ae18dc