### PR TITLE
fix: include country env in fleet deployments

### DIFF
--- a/news/220.bugfix.md
+++ b/news/220.bugfix.md
@@ -1,0 +1,1 @@
+Add SERVER_COUNTRIES env to fleet deployments to include country alongside city.

--- a/src/proxy2vpn/fleet_manager.py
+++ b/src/proxy2vpn/fleet_manager.py
@@ -319,7 +319,10 @@ class FleetManager:
         if service_plan.hostname:
             labels["vpn.hostname"] = service_plan.hostname
 
-        env = {"VPN_SERVICE_PROVIDER": service_plan.provider}
+        env = {
+            "VPN_SERVICE_PROVIDER": service_plan.provider,
+            "SERVER_COUNTRIES": service_plan.country,
+        }
         if service_plan.hostname:
             env["SERVER_HOSTNAMES"] = service_plan.hostname
         else:

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -41,6 +41,7 @@ def test_plan_deployment_basic_allocation(fleet_manager, monkeypatch):
     ]
     assert [s.profile for s in plan.services] == ["acc1", "acc2"]
     assert [s.port for s in plan.services] == [30000, 30001]
+    assert [s.country for s in plan.services] == ["A", "B"]
 
 
 def test_plan_deployment_sanitizes_and_limits(fleet_manager, monkeypatch):
@@ -116,6 +117,20 @@ def test_plan_deployment_unique_ips(fleet_manager):
     assert len(set(hostnames)) == 3
     ips = [s.ip for s in plan.services]
     assert len(set(ips)) == 3
+
+
+def test_create_service_from_plan_includes_country_env(fleet_manager):
+    sp = ServicePlan(
+        name="prov-a-city1",
+        profile="acc",
+        location="City1",
+        country="A",
+        port=20000,
+        provider="prov",
+    )
+    svc = fleet_manager._create_service_from_plan(sp)
+    assert svc.environment["SERVER_CITIES"] == "City1"
+    assert svc.environment["SERVER_COUNTRIES"] == "A"
 
 
 def test_plan_deployment_missing_profile(fleet_manager, monkeypatch):
@@ -270,7 +285,11 @@ def test_start_services_sequential_passes_service_name(monkeypatch, tmp_path):
         provider="prov",
         profile="acc",
         location="city1",
-        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city1"},
+        environment={
+            "VPN_SERVICE_PROVIDER": "prov",
+            "SERVER_CITIES": "city1",
+            "SERVER_COUNTRIES": "a",
+        },
         labels={
             "vpn.type": "vpn",
             "vpn.port": "21000",
@@ -319,7 +338,11 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
         provider="prov",
         profile="acc1",
         location="city1",
-        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city1"},
+        environment={
+            "VPN_SERVICE_PROVIDER": "prov",
+            "SERVER_CITIES": "city1",
+            "SERVER_COUNTRIES": "a",
+        },
         labels={
             "vpn.type": "vpn",
             "vpn.port": "20000",
@@ -334,7 +357,11 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
         provider="prov",
         profile="acc1",
         location="city2",
-        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city2"},
+        environment={
+            "VPN_SERVICE_PROVIDER": "prov",
+            "SERVER_CITIES": "city2",
+            "SERVER_COUNTRIES": "a",
+        },
         labels={
             "vpn.type": "vpn",
             "vpn.port": "20001",
@@ -349,7 +376,11 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
         provider="prov",
         profile="acc2",
         location="city3",
-        environment={"VPN_SERVICE_PROVIDER": "prov", "SERVER_CITIES": "city3"},
+        environment={
+            "VPN_SERVICE_PROVIDER": "prov",
+            "SERVER_CITIES": "city3",
+            "SERVER_COUNTRIES": "b",
+        },
         labels={
             "vpn.type": "vpn",
             "vpn.port": "20002",


### PR DESCRIPTION
## Summary
- always set `SERVER_COUNTRIES` when creating fleet services
- test fleet planning and deployment includes country env
- document change in news fragment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac30235dc0832fa38521fc2ddbaae6