### PR TITLE
feat: expose control API via localhost ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ uvx proxy2vpn --help
 
 ## HTTP Control Server
 
-Each VPN container exposes an HTTP control API on port `8000` internally. Control commands automatically use secure internal Docker networking to communicate with containers.
+Each VPN container exposes an HTTP control API on port `8000` which is mapped to a unique localhost-only port (starting at `30000`) on the host for secure access.
 
 ### Sample compose snippet
 

--- a/news/230.feature.md
+++ b/news/230.feature.md
@@ -1,0 +1,1 @@
+Expose control API via localhost-bound ports with separate allocation range.

--- a/src/proxy2vpn/cli.py
+++ b/src/proxy2vpn/cli.py
@@ -48,12 +48,11 @@ def _service_control_base_url(ctx: typer.Context, name: str) -> str:
     compose_file: Path = ctx.obj.get("compose_file", config.COMPOSE_FILE)
     manager = ComposeManager(compose_file)
     try:
-        manager.get_service(name)
+        svc = manager.get_service(name)
     except KeyError:
         abort(f"Service '{name}' not found")
 
-    # Always use internal Docker networking for security
-    return f"internal://{name}:8000/v1"
+    return f"http://localhost:{svc.control_port}/v1"
 
 
 @app.callback(invoke_without_command=True)
@@ -202,6 +201,7 @@ def profile_apply(
     profile: str,
     service: str,
     port: int = typer.Option(0, help="Host port to expose; 0 for auto"),
+    control_port: int = typer.Option(0, help="Control port; 0 for auto"),
 ):
     """Create a VPN service from a profile."""
 
@@ -216,10 +216,15 @@ def profile_apply(
         )
     if port == 0:
         port = manager.next_available_port(config.DEFAULT_PORT_START)
+    if control_port == 0:
+        control_port = manager.next_available_control_port(
+            config.DEFAULT_CONTROL_PORT_START
+        )
     env = {"VPN_SERVICE_PROVIDER": config.DEFAULT_PROVIDER}
     labels = {
         "vpn.type": "vpn",
         "vpn.port": str(port),
+        "vpn.control_port": str(control_port),
         "vpn.provider": config.DEFAULT_PROVIDER,
         "vpn.profile": profile,
         "vpn.location": "",
@@ -227,6 +232,7 @@ def profile_apply(
     svc = VPNService(
         name=service,
         port=port,
+        control_port=control_port,
         provider=config.DEFAULT_PROVIDER,
         profile=profile,
         location="",
@@ -235,7 +241,7 @@ def profile_apply(
     )
     manager.add_service(svc)
     console.print(
-        f"[green]✓[/green] Service '{service}' created from profile '{profile}' on port {port}.",
+        f"[green]✓[/green] Service '{service}' created from profile '{profile}' on port {port} (control {control_port}).",
     )
 
 
@@ -268,6 +274,11 @@ def vpn_create(
         callback=validate_port,
         help="Host port to expose; 0 for auto",
     ),
+    control_port: int = typer.Option(
+        0,
+        callback=validate_port,
+        help="Control port; 0 for auto",
+    ),
     provider: str = typer.Option(config.DEFAULT_PROVIDER),
     location: str = typer.Option("", help="Optional location, e.g. city"),
     force: bool = typer.Option(
@@ -287,6 +298,10 @@ def vpn_create(
         )
     if port == 0:
         port = manager.next_available_port(config.DEFAULT_PORT_START)
+    if control_port == 0:
+        control_port = manager.next_available_control_port(
+            config.DEFAULT_CONTROL_PORT_START
+        )
 
     env = {"VPN_SERVICE_PROVIDER": provider}
     location = location.strip()
@@ -305,6 +320,7 @@ def vpn_create(
     labels = {
         "vpn.type": "vpn",
         "vpn.port": str(port),
+        "vpn.control_port": str(control_port),
         "vpn.provider": provider,
         "vpn.profile": profile,
         "vpn.location": location,
@@ -312,6 +328,7 @@ def vpn_create(
     svc = VPNService(
         name=name,
         port=port,
+        control_port=control_port,
         provider=provider,
         profile=profile,
         location=location,
@@ -319,7 +336,9 @@ def vpn_create(
         labels=labels,
     )
     manager.add_service(svc)
-    console.print(f"[green]✓[/green] Service '{name}' created on port {port}.")
+    console.print(
+        f"[green]✓[/green] Service '{name}' created on port {port} (control {control_port})."
+    )
 
 
 @vpn_app.command("list")
@@ -753,30 +772,12 @@ async def vpn_status(
     ctx: typer.Context,
     service: str = typer.Argument(..., callback=sanitize_name),
 ):
-    """Show control server status for SERVICE.
-
-    Uses internal Docker networking to communicate with the container's control API.
-    Optional basic auth can be provided via the `GLUETUN_CONTROL_AUTH` env var.
-    """
+    """Show control server status for SERVICE."""
 
     base_url = _service_control_base_url(ctx, service)
-
-    # Handle internal Docker network requests
-    if base_url.startswith("internal://"):
-        from .docker_ops import docker_network_request
-        import json
-
-        container_name = service
-        try:
-            response = docker_network_request(container_name, "/v1/openvpn/status")
-            data = json.loads(response)
-            console.print_json(data=data)
-        except Exception as e:
-            abort(f"Failed to get status via internal network: {e}")
-    else:
-        async with GluetunControlClient(base_url) as client:
-            data = await client.status()
-        console.print_json(data=asdict(data))
+    async with GluetunControlClient(base_url) as client:
+        data = await client.status()
+    console.print_json(data=asdict(data))
 
 
 @vpn_app.command("public-ip")
@@ -785,30 +786,12 @@ async def vpn_public_ip(
     ctx: typer.Context,
     service: str = typer.Argument(..., callback=sanitize_name),
 ):
-    """Show public IP reported by the control API for SERVICE.
-
-    Uses internal Docker networking to communicate with the container's control API.
-    Optional basic auth can be provided via the `GLUETUN_CONTROL_AUTH` env var.
-    """
+    """Show public IP reported by the control API for SERVICE."""
 
     base_url = _service_control_base_url(ctx, service)
-
-    # Handle internal Docker network requests
-    if base_url.startswith("internal://"):
-        from .docker_ops import docker_network_request
-        import json
-
-        container_name = service
-        try:
-            response = docker_network_request(container_name, "/v1/publicip/ip")
-            data = json.loads(response)
-            console.print(data.get("public_ip", "N/A"))
-        except Exception as e:
-            abort(f"Failed to get public IP via internal network: {e}")
-    else:
-        async with GluetunControlClient(base_url) as client:
-            ip = await client.public_ip()
-        console.print(ip.ip)
+    async with GluetunControlClient(base_url) as client:
+        ip = await client.public_ip()
+    console.print(ip.ip)
 
 
 @vpn_app.command("restart-tunnel")
@@ -817,30 +800,12 @@ async def vpn_restart_tunnel(
     ctx: typer.Context,
     service: str = typer.Argument(..., callback=sanitize_name),
 ):
-    """Restart the VPN tunnel for SERVICE via the control API.
-
-    Uses internal Docker networking to communicate with the container's control API.
-    Optional basic auth can be provided via the `GLUETUN_CONTROL_AUTH` env var.
-    """
+    """Restart the VPN tunnel for SERVICE via the control API."""
 
     base_url = _service_control_base_url(ctx, service)
-
-    # Handle internal Docker network requests
-    if base_url.startswith("internal://"):
-        from .docker_ops import docker_network_request
-
-        container_name = service
-        try:
-            docker_network_request(
-                container_name, "/v1/openvpn/actions/restart", method="PUT"
-            )
-            console.print("[green]\u2713[/green] Tunnel restart requested.")
-        except Exception as e:
-            abort(f"Failed to restart tunnel via internal network: {e}")
-    else:
-        async with GluetunControlClient(base_url) as client:
-            await client.restart_tunnel()
-        console.print("[green]\u2713[/green] Tunnel restart requested.")
+    async with GluetunControlClient(base_url) as client:
+        await client.restart_tunnel()
+    console.print("[green]\u2713[/green] Tunnel restart requested.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/proxy2vpn/compose_manager.py
+++ b/src/proxy2vpn/compose_manager.py
@@ -12,6 +12,7 @@ from ruamel.yaml.mergevalue import MergeValue
 
 from .models import Profile, VPNService
 from .compose_validator import validate_compose
+from . import config
 
 # Minimal compose template used when initializing a new project
 INITIAL_COMPOSE_TEMPLATE = """\
@@ -193,6 +194,19 @@ class ComposeManager:
 
         port = start or 20000
         used = {svc.port for svc in self.list_services()}
+        while port in used:
+            port += 1
+        return port
+
+    def next_available_control_port(self, start: int = 0) -> int:
+        """Find the next available control port starting from START.
+
+        Control ports are kept in a separate range from proxy ports and are
+        bound to localhost for security.
+        """
+
+        port = start or config.DEFAULT_CONTROL_PORT_START
+        used = {svc.control_port for svc in self.list_services()}
         while port in used:
             port += 1
         return port

--- a/src/proxy2vpn/config.py
+++ b/src/proxy2vpn/config.py
@@ -28,6 +28,10 @@ DEFAULT_PROVIDER = "protonvpn"
 # this value.
 DEFAULT_PORT_START = 20000
 
+# Starting port used when allocating host ports for the control API.
+# Control ports are bound to localhost and kept separate from proxy ports.
+DEFAULT_CONTROL_PORT_START = 30000
+
 # URL of the gluetun server list JSON file.  This file is fetched and
 # cached by :class:`ServerManager` to provide location validation and
 # listing of available servers.

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -167,7 +167,10 @@ def create_vpn_container(service: VPNService, profile: Profile) -> Container:
         env = _load_env_file(profile.env_file)
         env.update(service.environment)
         ensure_network()
-        port_bindings = {"8888/tcp": service.port}
+        port_bindings = {
+            "8888/tcp": service.port,
+            "8000/tcp": ("127.0.0.1", service.control_port),
+        }
         container = client.containers.create(
             profile.image,
             name=service.name,
@@ -609,45 +612,3 @@ def test_vpn_connection(name: str) -> bool:
     raise RuntimeError(
         "test_vpn_connection() cannot be called from an async context; use test_vpn_connection_async()."
     )
-
-
-def docker_network_request(
-    container_name: str, url_path: str, method: str = "GET"
-) -> str:
-    """Make an HTTP request to a container via Docker internal network.
-
-    Args:
-        container_name: Name of the target container
-        url_path: Path to request (e.g., "/v1/publicip/ip")
-        method: HTTP method (default: GET)
-
-    Returns:
-        Response body as string
-
-    Raises:
-        RuntimeError: If the request fails or container is not accessible
-    """
-    client = _client()
-
-    # Create a temporary container to make the HTTP request
-    network_name = "proxy2vpn_network"
-    image = "curlimages/curl:latest"
-
-    target_url = f"http://{container_name}:8000{url_path}"
-    command = ["curl", "-s", "-X", method, target_url]
-
-    try:
-        # Run curl command in a temporary container on the same network
-        result = client.containers.run(
-            image=image,
-            command=command,
-            network=network_name,
-            remove=True,
-            stdout=True,
-            stderr=True,
-        )
-        return result.decode("utf-8").strip()
-    except DockerException as exc:
-        raise RuntimeError(
-            f"Failed to make request to {container_name}: {exc}"
-        ) from exc

--- a/src/proxy2vpn/fleet_manager.py
+++ b/src/proxy2vpn/fleet_manager.py
@@ -23,6 +23,7 @@ class FleetConfig:
     countries: list[str]  # ["Germany", "France", "Netherlands"]
     profiles: dict[str, int]  # {"acc1": 2, "acc2": 8} - profile slots
     port_start: int = 20000
+    control_port_start: int = 30000
     naming_template: str = "{provider}-{country}-{city}"
     max_per_profile: int | None = None  # Limit services per profile
     unique_ips: bool = False  # Ensure unique city/IP combinations
@@ -37,6 +38,7 @@ class ServicePlan:
     location: str
     country: str
     port: int
+    control_port: int
     provider: str
     hostname: str | None = None
     ip: str | None = None
@@ -60,6 +62,7 @@ class DeploymentPlan:
         location: str,
         country: str,
         port: int,
+        control_port: int,
         provider: str,
         hostname: str | None = None,
         ip: str | None = None,
@@ -72,6 +75,7 @@ class DeploymentPlan:
                 location=location,
                 country=country,
                 port=port,
+                control_port=control_port,
                 provider=provider or self.provider,
                 hostname=hostname,
                 ip=ip,
@@ -92,6 +96,7 @@ class DeploymentPlan:
                     "provider": s.provider,
                     "hostname": s.hostname,
                     "ip": s.ip,
+                    "control_port": s.control_port,
                 }
                 for s in self.services
             ],
@@ -173,6 +178,7 @@ class FleetManager:
 
             self.profile_allocator.setup_profiles(config.profiles)
             current_port = config.port_start
+            current_control_port = config.control_port_start
 
             for country, city, hostname, ip in all_entries:
                 profile_slot = self.profile_allocator.get_next_available(
@@ -195,6 +201,7 @@ class FleetManager:
                     location=city,
                     country=country,
                     port=current_port,
+                    control_port=current_control_port,
                     provider=config.provider,
                     hostname=hostname,
                     ip=ip,
@@ -202,6 +209,7 @@ class FleetManager:
 
                 self.profile_allocator.allocate_slot(profile_slot.name, service_name)
                 current_port += 1
+                current_control_port += 1
 
             return plan
 
@@ -233,6 +241,7 @@ class FleetManager:
         self.profile_allocator.setup_profiles(config.profiles)
 
         current_port = config.port_start
+        current_control_port = config.control_port_start
 
         for country, city in all_cities:
             profile_slot = self.profile_allocator.get_next_available(config.profiles)
@@ -253,11 +262,13 @@ class FleetManager:
                 location=city,
                 country=country,
                 port=current_port,
+                control_port=current_control_port,
                 provider=config.provider,
             )
 
             self.profile_allocator.allocate_slot(profile_slot.name, service_name)
             current_port += 1
+            current_control_port += 1
 
         return plan
 
@@ -312,6 +323,7 @@ class FleetManager:
         labels = {
             "vpn.type": "vpn",
             "vpn.port": str(service_plan.port),
+            "vpn.control_port": str(service_plan.control_port),
             "vpn.provider": service_plan.provider,
             "vpn.profile": service_plan.profile,
             "vpn.location": service_plan.location,
@@ -331,6 +343,7 @@ class FleetManager:
         return VPNService(
             name=service_plan.name,
             port=service_plan.port,
+            control_port=service_plan.control_port,
             provider=service_plan.provider,
             profile=service_plan.profile,
             location=service_plan.location,

--- a/src/proxy2vpn/models.py
+++ b/src/proxy2vpn/models.py
@@ -10,6 +10,7 @@ from .validators import sanitize_name, sanitize_path, validate_port
 class VPNService:
     name: str
     port: int
+    control_port: int
     provider: str
     profile: str
     location: str
@@ -19,11 +20,13 @@ class VPNService:
     def __post_init__(self) -> None:
         self.name = sanitize_name(self.name)
         self.port = validate_port(self.port)
+        self.control_port = validate_port(self.control_port)
 
     @classmethod
     def from_compose_service(cls, name: str, service_def: dict) -> "VPNService":
         ports = service_def.get("ports", [])
         host_port = 0
+        control_host_port = 0
         for mapping in ports:
             mapping = str(mapping)
             parts = mapping.split(":")
@@ -39,6 +42,8 @@ class VPNService:
             container_port = container.split("/")[0]
             if container_port == "8888" and host_port == 0:
                 host_port = host
+            if container_port == "8000" and control_host_port == 0:
+                control_host_port = host
         env_list = service_def.get("environment", [])
         env_dict: dict[str, str] = {}
         for item in env_list:
@@ -52,6 +57,7 @@ class VPNService:
         return cls(
             name=name,
             port=host_port,
+            control_port=control_host_port,
             provider=provider,
             profile=profile,
             location=location,
@@ -61,9 +67,13 @@ class VPNService:
 
     def to_compose_service(self) -> dict:
         env_list = [f"{k}={v}" for k, v in self.environment.items()]
-        ports = [f"0.0.0.0:{self.port}:8888/tcp"]
+        ports = [
+            f"0.0.0.0:{self.port}:8888/tcp",
+            f"127.0.0.1:{self.control_port}:8000/tcp",
+        ]
         labels = dict(self.labels)
         labels.setdefault("vpn.port", str(self.port))
+        labels.setdefault("vpn.control_port", str(self.control_port))
         service = {
             "ports": ports,
             "environment": env_list,

--- a/tests/test_cli_control.py
+++ b/tests/test_cli_control.py
@@ -1,7 +1,5 @@
 import pathlib
-import sys
-
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from dataclasses import dataclass
 
 from typer.testing import CliRunner
 
@@ -11,78 +9,90 @@ from proxy2vpn import cli
 COMPOSE_FILE = pathlib.Path(__file__).with_name("test_compose.yml")
 
 
-def test_vpn_status_uses_internal_networking(monkeypatch):
+@dataclass
+class _Status:
+    status: str
+    openvpn: str
+
+
+@dataclass
+class _IP:
+    ip: str
+
+
+@dataclass
+class _Restart:
+    status: str
+
+
+class DummyClient:
+    def __init__(self, base_url):
+        self.base_url = base_url
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def status(self):
+        return _Status(status="running", openvpn="enabled")
+
+    async def public_ip(self):
+        return _IP(ip="1.2.3.4")
+
+    async def restart_tunnel(self):
+        return _Restart(status="restarted")
+
+
+def test_vpn_status_uses_localhost(monkeypatch):
     runner = CliRunner()
     called = {}
 
-    def fake_docker_request(container_name, url_path, method="GET"):
-        called["container_name"] = container_name
-        called["url_path"] = url_path
-        called["method"] = method
-        return '{"status": "running"}'
+    def fake_client(base_url):
+        called["base_url"] = base_url
+        return DummyClient(base_url)
 
-    # Mock the docker network request function that gets imported dynamically
-    import proxy2vpn.docker_ops
-
-    monkeypatch.setattr(
-        proxy2vpn.docker_ops, "docker_network_request", fake_docker_request
-    )
+    monkeypatch.setattr(cli, "GluetunControlClient", fake_client)
 
     result = runner.invoke(
-        cli.app,
-        ["--compose-file", str(COMPOSE_FILE), "vpn", "status", "testvpn1"],
+        cli.app, ["--compose-file", str(COMPOSE_FILE), "vpn", "status", "testvpn1"]
     )
     assert result.exit_code == 0
-    assert called["container_name"] == "testvpn1"
-    assert called["url_path"] == "/v1/openvpn/status"
+    assert called["base_url"] == "http://localhost:30000/v1"
 
 
-def test_vpn_public_ip_uses_internal_networking(monkeypatch):
+def test_vpn_public_ip_uses_localhost(monkeypatch):
     runner = CliRunner()
     called = {}
 
-    def fake_docker_request(container_name, url_path, method="GET"):
-        called["container_name"] = container_name
-        called["url_path"] = url_path
-        called["method"] = method
-        return '{"ip": "1.2.3.4"}'
+    def fake_client(base_url):
+        called["base_url"] = base_url
+        return DummyClient(base_url)
 
-    import proxy2vpn.docker_ops
-
-    monkeypatch.setattr(
-        proxy2vpn.docker_ops, "docker_network_request", fake_docker_request
-    )
+    monkeypatch.setattr(cli, "GluetunControlClient", fake_client)
 
     result = runner.invoke(
         cli.app,
         ["--compose-file", str(COMPOSE_FILE), "vpn", "public-ip", "testvpn1"],
     )
     assert result.exit_code == 0
-    assert called["container_name"] == "testvpn1"
-    assert called["url_path"] == "/v1/publicip/ip"
+    assert called["base_url"] == "http://localhost:30000/v1"
 
 
-def test_vpn_restart_tunnel_uses_internal_networking(monkeypatch):
+def test_vpn_restart_tunnel_uses_localhost(monkeypatch):
     runner = CliRunner()
     called = {}
 
-    def fake_docker_request(container_name, url_path, method="GET"):
-        called["container_name"] = container_name
-        called["url_path"] = url_path
-        called["method"] = method
-        return '{"status": "restarted"}'
+    def fake_client(base_url):
+        called["base_url"] = base_url
+        return DummyClient(base_url)
 
-    import proxy2vpn.docker_ops
-
-    monkeypatch.setattr(
-        proxy2vpn.docker_ops, "docker_network_request", fake_docker_request
-    )
+    monkeypatch.setattr(cli, "GluetunControlClient", fake_client)
 
     result = runner.invoke(
         cli.app,
         ["--compose-file", str(COMPOSE_FILE), "vpn", "restart-tunnel", "testvpn1"],
     )
     assert result.exit_code == 0
-    assert called["container_name"] == "testvpn1"
-    assert called["url_path"] == "/v1/openvpn/actions/restart"
-    assert called["method"] == "PUT"
+    assert called["base_url"] == "http://localhost:30000/v1"

--- a/tests/test_cli_vpn_list.py
+++ b/tests/test_cli_vpn_list.py
@@ -41,6 +41,7 @@ def test_vpn_list_includes_provider_and_location(monkeypatch):
     svc = VPNService(
         name="svc",
         port=8080,
+        control_port=30000,
         provider="prov",
         profile="pro",
         location="US",

--- a/tests/test_compose.yml
+++ b/tests/test_compose.yml
@@ -17,20 +17,24 @@ services:
     <<: *vpn-base-test
     ports:
       - "0.0.0.0:9999:8888/tcp"
+      - "127.0.0.1:30000:8000/tcp"
     environment:
       - SERVER_CITIES=New York
     labels:
       vpn.type: vpn
       vpn.port: "9999"
+      vpn.control_port: "30000"
       vpn.profile: test
 
   testvpn2:
     <<: *vpn-base-test
     ports:
       - "0.0.0.0:9998:8888/tcp"
+      - "127.0.0.1:30001:8000/tcp"
     environment:
       - SERVER_CITIES=Chicago
     labels:
       vpn.type: vpn
       vpn.port: "9998"
+      vpn.control_port: "30001"
       vpn.profile: test

--- a/tests/test_compose_manager.py
+++ b/tests/test_compose_manager.py
@@ -43,6 +43,7 @@ def test_add_and_remove_service(tmp_path):
     new_service = VPNService(
         name="vpn3",
         port=7777,
+        control_port=30002,
         provider="protonvpn",
         profile="test",
         location="LA",
@@ -53,6 +54,7 @@ def test_add_and_remove_service(tmp_path):
         labels={
             "vpn.type": "vpn",
             "vpn.port": "8888",
+            "vpn.control_port": "30002",
             "vpn.provider": "protonvpn",
             "vpn.profile": "test",
             "vpn.location": "LA",
@@ -79,6 +81,7 @@ def test_add_service_after_init(tmp_path):
     service = VPNService(
         name="vpn1",
         port=12345,
+        control_port=30003,
         provider="protonvpn",
         profile="andr",
         location="LA",
@@ -89,6 +92,7 @@ def test_add_service_after_init(tmp_path):
         labels={
             "vpn.type": "vpn",
             "vpn.port": "12345",
+            "vpn.control_port": "30003",
             "vpn.provider": "protonvpn",
             "vpn.profile": "andr",
             "vpn.location": "LA",
@@ -98,6 +102,7 @@ def test_add_service_after_init(tmp_path):
     compose_text = compose_path.read_text()
     assert "<<: *vpn-base-andr" in compose_text
     assert "0.0.0.0:12345:8888/tcp" in compose_text
+    assert "127.0.0.1:30003:8000/tcp" in compose_text
 
 
 def test_recover_from_corruption(tmp_path):

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -183,6 +183,7 @@ def test_create_vpn_container_merges_env(tmp_path):
     service = docker_ops.VPNService(
         name="vpn-test",
         port=12345,
+        control_port=30000,
         provider="",
         profile="test",
         location="",
@@ -204,6 +205,7 @@ def test_recreate_vpn_container():
     service = docker_ops.VPNService(
         name="vpn-recreate",
         port=12346,
+        control_port=30001,
         provider="",
         profile="test",
         location="",
@@ -222,6 +224,7 @@ def test_start_all_vpn_containers_recreates(monkeypatch):
     svc = docker_ops.VPNService(
         name="svc",
         port=1,
+        control_port=30002,
         provider="",
         profile="p",
         location="",

--- a/tests/test_fleet_compose.yml
+++ b/tests/test_fleet_compose.yml
@@ -35,20 +35,24 @@ services:
     <<: *vpn-base-test
     ports:
       - "0.0.0.0:9999:8888/tcp"
+      - "127.0.0.1:30000:8000/tcp"
     environment:
       - SERVER_CITIES=New York
     labels:
       vpn.type: vpn
       vpn.port: "9999"
+      vpn.control_port: "30000"
       vpn.profile: test
 
   testvpn2:
     <<: *vpn-base-test
     ports:
       - "0.0.0.0:9998:8888/tcp"
+      - "127.0.0.1:30001:8000/tcp"
     environment:
       - SERVER_CITIES=Chicago
     labels:
       vpn.type: vpn
       vpn.port: "9998"
+      vpn.control_port: "30001"
       vpn.profile: test

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -126,6 +126,7 @@ def test_create_service_from_plan_includes_country_env(fleet_manager):
         location="City1",
         country="A",
         port=20000,
+        control_port=30000,
         provider="prov",
     )
     svc = fleet_manager._create_service_from_plan(sp)
@@ -159,6 +160,7 @@ def test_deploy_fleet_rolls_back_on_error(monkeypatch, fleet_manager, capsys):
             location="L1",
             country="C",
             port=10000,
+            control_port=30000,
             provider="prov",
         ),
         ServicePlan(
@@ -167,6 +169,7 @@ def test_deploy_fleet_rolls_back_on_error(monkeypatch, fleet_manager, capsys):
             location="L2",
             country="C",
             port=10001,
+            control_port=30001,
             provider="prov",
         ),
     ]
@@ -225,6 +228,7 @@ def test_deploy_fleet_skips_invalid_locations(monkeypatch, fleet_manager, capsys
             location="good",
             country="C",
             port=10000,
+            control_port=30000,
             provider="prov",
         ),
         ServicePlan(
@@ -233,6 +237,7 @@ def test_deploy_fleet_skips_invalid_locations(monkeypatch, fleet_manager, capsys
             location="bad",
             country="C",
             port=10001,
+            control_port=30001,
             provider="prov",
         ),
     ]
@@ -282,6 +287,7 @@ def test_start_services_sequential_passes_service_name(monkeypatch, tmp_path):
     svc = VPNService(
         name="prov-a-city1",
         port=21000,
+        control_port=30000,
         provider="prov",
         profile="acc",
         location="city1",
@@ -293,6 +299,7 @@ def test_start_services_sequential_passes_service_name(monkeypatch, tmp_path):
         labels={
             "vpn.type": "vpn",
             "vpn.port": "21000",
+            "vpn.control_port": "30000",
             "vpn.provider": "prov",
             "vpn.profile": "acc",
             "vpn.location": "city1",
@@ -335,6 +342,7 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
     svc1 = VPNService(
         name="prov-a-city1",
         port=20000,
+        control_port=31000,
         provider="prov",
         profile="acc1",
         location="city1",
@@ -346,6 +354,7 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
         labels={
             "vpn.type": "vpn",
             "vpn.port": "20000",
+            "vpn.control_port": "31000",
             "vpn.provider": "prov",
             "vpn.profile": "acc1",
             "vpn.location": "city1",
@@ -354,6 +363,7 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
     svc2 = VPNService(
         name="prov-a-city2",
         port=20001,
+        control_port=31001,
         provider="prov",
         profile="acc1",
         location="city2",
@@ -365,6 +375,7 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
         labels={
             "vpn.type": "vpn",
             "vpn.port": "20001",
+            "vpn.control_port": "31001",
             "vpn.provider": "prov",
             "vpn.profile": "acc1",
             "vpn.location": "city2",
@@ -373,6 +384,7 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
     svc3 = VPNService(
         name="prov-b-city3",
         port=20002,
+        control_port=31002,
         provider="prov",
         profile="acc2",
         location="city3",
@@ -384,6 +396,7 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
         labels={
             "vpn.type": "vpn",
             "vpn.port": "20002",
+            "vpn.control_port": "31002",
             "vpn.provider": "prov",
             "vpn.profile": "acc2",
             "vpn.location": "city3",

--- a/tests/test_integration_workflow.py
+++ b/tests/test_integration_workflow.py
@@ -33,11 +33,17 @@ def test_end_to_end_workflow(tmp_path):
     service = VPNService(
         name="vpn1",
         port=12346,
+        control_port=30000,
         provider="",
         profile="test",
         location="",
         environment={},
-        labels={"vpn.type": "vpn", "vpn.port": "12346", "vpn.profile": "test"},
+        labels={
+            "vpn.type": "vpn",
+            "vpn.port": "12346",
+            "vpn.control_port": "30000",
+            "vpn.profile": "test",
+        },
     )
     manager.add_service(service)
     docker_ops.create_vpn_container(service, profile)

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -42,11 +42,12 @@ def test_monitor_vpn_health(tmp_path):
     service = docker_ops.VPNService(
         name="vpn-test",
         port=12345,
+        control_port=30000,
         provider="",
         profile="test",
         location="",
         environment={},
-        labels={"vpn.type": "vpn", "vpn.port": "12345"},
+        labels={"vpn.type": "vpn", "vpn.port": "12345", "vpn.control_port": "30000"},
     )
     docker_ops.create_vpn_container(service, profile)
     docker_ops.start_container(service.name)

--- a/tests/test_profile_apply.py
+++ b/tests/test_profile_apply.py
@@ -31,8 +31,10 @@ def test_profile_apply(tmp_path):
         manager = ComposeManager(compose_path)
         profiles = {p.name for p in manager.list_profiles()}
         assert "test" in profiles
-        cli.profile_apply(ctx, "test", "vpn3", port=7777)
+        cli.profile_apply(ctx, "test", "vpn3", port=7777, control_port=0)
     manager = ComposeManager(compose_path)
     svc = manager.get_service("vpn3")
     assert svc.port == 7777
     assert svc.labels.get("vpn.port") == "7777"
+    assert svc.control_port == 30002
+    assert svc.labels.get("vpn.control_port") == "30002"

--- a/tests/test_server_monitor.py
+++ b/tests/test_server_monitor.py
@@ -15,6 +15,7 @@ def test_check_service_health_uses_authenticated_proxy(monkeypatch):
     service = models.VPNService(
         name="vpn-test",
         port=8080,
+        control_port=30000,
         provider="",
         profile="",
         location="",


### PR DESCRIPTION
## Summary
- bind control server to localhost ports instead of internal network
- allocate control ports from a separate range
- document new control port behavior

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac37492b8c832fafbf0369f2915d56