### PR TITLE
fix: preserve control API path for Gluetun client

### DIFF
--- a/news/240.bugfix.md
+++ b/news/240.bugfix.md
@@ -1,0 +1,1 @@
+Preserve control API base path in Gluetun client to avoid unauthorized errors when using versioned endpoints.

--- a/src/proxy2vpn/http_client.py
+++ b/src/proxy2vpn/http_client.py
@@ -210,6 +210,7 @@ class GluetunControlClient(HTTPClient):
             if not sep:
                 raise ValueError("GLUETUN_CONTROL_AUTH must be in 'user:pass' format")
             auth = (username, password)
+        self._base_path = parsed.path.rstrip("/")
         config = HTTPClientConfig(
             base_url=f"{parsed.scheme}://{parsed.netloc}",
             timeout=timeout,
@@ -218,20 +219,25 @@ class GluetunControlClient(HTTPClient):
         )
         super().__init__(config)
 
+    def _endpoint(self, endpoint: str) -> str:
+        return f"{self._base_path}{endpoint}"
+
     async def status(self) -> StatusResponse:
-        data = await self.get(self.ENDPOINTS["status"])
+        data = await self.get(self._endpoint(self.ENDPOINTS["status"]))
         return StatusResponse(**data)
 
     async def set_openvpn(self, enabled: bool) -> OpenVPNResponse:
         payload = {"status": enabled}
-        data = await self.post(self.ENDPOINTS["openvpn"], json=payload)
+        data = await self.post(self._endpoint(self.ENDPOINTS["openvpn"]), json=payload)
         return OpenVPNResponse(**data)
 
     async def public_ip(self) -> IPResponse:
-        data = await self.get(self.ENDPOINTS["ip"])
+        data = await self.get(self._endpoint(self.ENDPOINTS["ip"]))
         return IPResponse(**data)
 
     async def restart_tunnel(self) -> OpenVPNStatusResponse:
         payload = {"status": "restarted"}
-        data = await self.request("PUT", self.ENDPOINTS["openvpn_status"], json=payload)
+        data = await self.request(
+            "PUT", self._endpoint(self.ENDPOINTS["openvpn_status"]), json=payload
+        )
         return OpenVPNStatusResponse(**data)

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -10,6 +10,26 @@ from proxy2vpn import control_client
 BASE_URL = "http://localhost:8000"
 
 
+def test_get_status_with_base_path(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_request(
+        self, method, path, **kwargs
+    ):  # pragma: no cover - simple mock
+        called["method"] = method
+        called["path"] = path
+        return {"status": "ok"}
+
+    monkeypatch.setattr(control_client.GluetunControlClient, "request", fake_request)
+    result = asyncio.run(control_client.get_status(f"{BASE_URL}/v1"))
+    assert result == {"status": "ok"}
+    assert called["method"] == "GET"
+    assert (
+        called["path"]
+        == "/v1" + control_client.GluetunControlClient.ENDPOINTS["status"]
+    )
+
+
 def test_get_status_calls_correct_url(monkeypatch):
     called: dict[str, object] = {}
 

--- a/tests/test_gluetun_control_client.py
+++ b/tests/test_gluetun_control_client.py
@@ -13,6 +13,20 @@ from proxy2vpn.http_client import (
 BASE_URL = "http://localhost:8000"
 
 
+def test_status_with_base_path(monkeypatch):
+    called = {}
+
+    async def fake_get(self, path, **kwargs):  # pragma: no cover - simple mock
+        called["path"] = path
+        return {"status": "ok"}
+
+    monkeypatch.setattr(HTTPClient, "get", fake_get)
+    client = GluetunControlClient(f"{BASE_URL}/v1")
+    result = asyncio.run(client.status())
+    assert result == StatusResponse(status="ok")
+    assert called["path"] == "/v1" + GluetunControlClient.ENDPOINTS["status"]
+
+
 def test_status_calls_correct_path(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- ensure Gluetun control client preserves base URL path so versioned endpoints resolve
- add regression tests for base path handling
- add news fragment

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac3b093c78832f9ff5e167783cb4a3