### PR TITLE
feat: add start_vpn_service helper

### DIFF
--- a/news/240.feature.md
+++ b/news/240.feature.md
@@ -1,0 +1,1 @@
+Added start_vpn_service helper to consolidate VPN container start logic and refactored fleet manager to use it.

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -224,6 +224,32 @@ def start_container(name: str) -> Container:
         raise  # Let the original exception propagate to preserve NotFound type
 
 
+def start_vpn_service(service: VPNService, profile: Profile, force: bool) -> Container:
+    """Ensure a VPN service container exists and is running.
+
+    If ``force`` is True the container is recreated before being started.
+    Otherwise an attempt is made to start an existing container and a new
+    one is created only if it does not already exist.
+    """
+
+    from docker.errors import NotFound
+
+    try:
+        if force:
+            container = recreate_vpn_container(service, profile)
+            _retry(container.start, exceptions=(DockerException,))
+            return container
+
+        try:
+            return start_container(service.name)
+        except NotFound:
+            container = create_vpn_container(service, profile)
+            _retry(container.start, exceptions=(DockerException,))
+            return container
+    except DockerException as exc:
+        raise RuntimeError(f"Failed to start container {service.name}: {exc}") from exc
+
+
 def stop_container(name: str) -> Container:
     """Stop a running container by name."""
     client = _client()
@@ -389,14 +415,10 @@ def start_all_vpn_containers(manager: ComposeManager) -> list[str]:
     """Recreate and start all VPN containers."""
 
     results: list[str] = []
-    try:
-        for svc in manager.list_services():
-            profile = manager.get_profile(svc.profile)
-            container = recreate_vpn_container(svc, profile)
-            _retry(container.start, exceptions=(DockerException,))
-            results.append(svc.name)
-    except DockerException as exc:
-        raise RuntimeError(f"Failed to start containers: {exc}") from exc
+    for svc in manager.list_services():
+        profile = manager.get_profile(svc.profile)
+        start_vpn_service(svc, profile, force=True)
+        results.append(svc.name)
     return results
 
 

--- a/src/proxy2vpn/fleet_manager.py
+++ b/src/proxy2vpn/fleet_manager.py
@@ -472,12 +472,7 @@ class FleetManager:
 
     async def _start_services_parallel(self, service_names: list[str], force: bool):
         """Start services in parallel with limited concurrency"""
-        from docker.errors import NotFound
-        from .docker_ops import (
-            create_vpn_container,
-            recreate_vpn_container,
-            start_container,
-        )
+        from .docker_ops import start_vpn_service
 
         semaphore = asyncio.Semaphore(5)  # Max 5 concurrent starts
 
@@ -490,20 +485,7 @@ class FleetManager:
                     service = self.compose_manager.get_service(service_name)
                     profile = self.compose_manager.get_profile(service.profile)
 
-                    # Create and start container
-                    if force:
-                        await asyncio.to_thread(
-                            recreate_vpn_container, service, profile
-                        )
-                        await asyncio.to_thread(start_container, service_name)
-                    else:
-                        try:
-                            await asyncio.to_thread(start_container, service_name)
-                        except NotFound:
-                            await asyncio.to_thread(
-                                create_vpn_container, service, profile
-                            )
-                            await asyncio.to_thread(start_container, service_name)
+                    await asyncio.to_thread(start_vpn_service, service, profile, force)
 
                     console.print(f"[green]✅[/green] Started {service_name}")
 
@@ -517,12 +499,7 @@ class FleetManager:
 
     async def _start_services_sequential(self, service_names: list[str], force: bool):
         """Start services one by one"""
-        from docker.errors import NotFound
-        from .docker_ops import (
-            create_vpn_container,
-            recreate_vpn_container,
-            start_container,
-        )
+        from .docker_ops import start_vpn_service
 
         for service_name in service_names:
             try:
@@ -532,16 +509,7 @@ class FleetManager:
                 service = self.compose_manager.get_service(service_name)
                 profile = self.compose_manager.get_profile(service.profile)
 
-                # Create and start container
-                if force:
-                    await asyncio.to_thread(recreate_vpn_container, service, profile)
-                    await asyncio.to_thread(start_container, service_name)
-                else:
-                    try:
-                        await asyncio.to_thread(start_container, service_name)
-                    except NotFound:
-                        await asyncio.to_thread(create_vpn_container, service, profile)
-                        await asyncio.to_thread(start_container, service_name)
+                await asyncio.to_thread(start_vpn_service, service, profile, force)
 
                 console.print(f"[green]✅[/green] Started {service_name}")
 

--- a/tests/test_docker_ops.py
+++ b/tests/test_docker_ops.py
@@ -242,24 +242,132 @@ def test_start_all_vpn_containers_recreates(monkeypatch):
         def get_profile(self, name):
             return profile
 
-    class DummyContainer:
-        status = "created"
+    called: list[tuple[str, str, bool]] = []
 
-        def start(self):
-            return None
+    def fake_start(service, profile, force):
+        called.append((service.name, profile.name, force))
 
-    called = {"recreate": 0}
-
-    def fake_recreate(service, profile):
-        called["recreate"] += 1
-        return DummyContainer()
-
-    monkeypatch.setattr(docker_ops, "recreate_vpn_container", fake_recreate)
-    monkeypatch.setattr(docker_ops, "_retry", lambda func, **kw: func())
+    monkeypatch.setattr(docker_ops, "start_vpn_service", fake_start)
 
     results = docker_ops.start_all_vpn_containers(Manager())
     assert results == ["svc"]
-    assert called["recreate"] == 1
+    assert called == [("svc", "p", True)]
+
+
+def test_start_vpn_service_force_recreates(monkeypatch):
+    svc = docker_ops.VPNService(
+        name="svc",
+        port=1,
+        control_port=30002,
+        provider="",
+        profile="p",
+        location="",
+        environment={},
+        labels={},
+    )
+    profile = docker_ops.Profile(
+        name="p", env_file="", image="alpine", cap_add=[], devices=[]
+    )
+
+    calls = {"recreate": 0, "start": 0}
+
+    class DummyContainer:
+        def start(self):
+            calls["start"] += 1
+
+    def fake_recreate(service, profile):
+        calls["recreate"] += 1
+        return DummyContainer()
+
+    def should_not_be_called(*args, **kwargs):  # pragma: no cover - fails if called
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(docker_ops, "recreate_vpn_container", fake_recreate)
+    monkeypatch.setattr(docker_ops, "create_vpn_container", should_not_be_called)
+    monkeypatch.setattr(docker_ops, "start_container", should_not_be_called)
+    monkeypatch.setattr(docker_ops, "_retry", lambda func, **kw: func())
+
+    docker_ops.start_vpn_service(svc, profile, force=True)
+    assert calls == {"recreate": 1, "start": 1}
+
+
+def test_start_vpn_service_creates_when_missing(monkeypatch):
+    from docker.errors import NotFound
+
+    svc = docker_ops.VPNService(
+        name="svc",
+        port=1,
+        control_port=30002,
+        provider="",
+        profile="p",
+        location="",
+        environment={},
+        labels={},
+    )
+    profile = docker_ops.Profile(
+        name="p", env_file="", image="alpine", cap_add=[], devices=[]
+    )
+
+    calls = {"start_container": 0, "create": 0, "start": 0}
+
+    def fake_start_container(name):
+        calls["start_container"] += 1
+        raise NotFound("missing")
+
+    class DummyContainer:
+        def start(self):
+            calls["start"] += 1
+
+    def fake_create(service, profile):
+        calls["create"] += 1
+        return DummyContainer()
+
+    def should_not_be_called(*args, **kwargs):  # pragma: no cover - fails if called
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(docker_ops, "start_container", fake_start_container)
+    monkeypatch.setattr(docker_ops, "create_vpn_container", fake_create)
+    monkeypatch.setattr(docker_ops, "recreate_vpn_container", should_not_be_called)
+    monkeypatch.setattr(docker_ops, "_retry", lambda func, **kw: func())
+
+    docker_ops.start_vpn_service(svc, profile, force=False)
+    assert calls == {"start_container": 1, "create": 1, "start": 1}
+
+
+def test_start_vpn_service_starts_existing(monkeypatch):
+    svc = docker_ops.VPNService(
+        name="svc",
+        port=1,
+        control_port=30002,
+        provider="",
+        profile="p",
+        location="",
+        environment={},
+        labels={},
+    )
+    profile = docker_ops.Profile(
+        name="p", env_file="", image="alpine", cap_add=[], devices=[]
+    )
+
+    calls = {"start_container": 0}
+
+    class DummyContainer:
+        pass
+
+    def fake_start_container(name):
+        calls["start_container"] += 1
+        return DummyContainer()
+
+    def should_not_be_called(*args, **kwargs):  # pragma: no cover - fails if called
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(docker_ops, "start_container", fake_start_container)
+    monkeypatch.setattr(docker_ops, "create_vpn_container", should_not_be_called)
+    monkeypatch.setattr(docker_ops, "recreate_vpn_container", should_not_be_called)
+
+    result = docker_ops.start_vpn_service(svc, profile, force=False)
+    assert calls["start_container"] == 1
+    assert isinstance(result, DummyContainer)
 
 
 def test_ensure_network_recreates(monkeypatch):

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -276,56 +276,6 @@ def test_deploy_fleet_skips_invalid_locations(monkeypatch, fleet_manager, capsys
     assert "Skipping 1 invalid service" in out
 
 
-def test_start_services_sequential_passes_service_name(monkeypatch, tmp_path):
-    compose_path = tmp_path / "compose.yml"
-    ComposeManager.create_initial_compose(compose_path, force=True)
-    fm = FleetManager(compose_file_path=compose_path)
-
-    profile = Profile(name="acc", env_file="")
-    fm.compose_manager.add_profile(profile)
-
-    svc = VPNService(
-        name="prov-a-city1",
-        port=21000,
-        control_port=30000,
-        provider="prov",
-        profile="acc",
-        location="city1",
-        environment={
-            "VPN_SERVICE_PROVIDER": "prov",
-            "SERVER_CITIES": "city1",
-            "SERVER_COUNTRIES": "a",
-        },
-        labels={
-            "vpn.type": "vpn",
-            "vpn.port": "21000",
-            "vpn.control_port": "30000",
-            "vpn.provider": "prov",
-            "vpn.profile": "acc",
-            "vpn.location": "city1",
-        },
-    )
-    fm.compose_manager.add_service(svc)
-
-    start_calls: list[str] = []
-
-    def fake_start(name):
-        start_calls.append(name)
-
-    def fake_recreate(service, profile):
-        class Dummy:
-            pass
-
-        return Dummy()
-
-    monkeypatch.setattr("proxy2vpn.docker_ops.start_container", fake_start)
-    monkeypatch.setattr("proxy2vpn.docker_ops.recreate_vpn_container", fake_recreate)
-
-    asyncio.run(fm._start_services_sequential([svc.name], True))
-
-    assert start_calls == [svc.name]
-
-
 def test_get_fleet_status_reconstructs_allocator(tmp_path):
     compose_path = tmp_path / "compose.yml"
     ComposeManager.create_initial_compose(compose_path, force=True)
@@ -413,3 +363,38 @@ def test_get_fleet_status_reconstructs_allocator(tmp_path):
     assert status["total_services"] == 3
     assert status["profile_counts"] == {"acc1": 2, "acc2": 1}
     assert status["country_counts"] == {"a": 2, "b": 1}
+
+
+def test_start_services_parallel_uses_helper(monkeypatch, fleet_manager):
+    from proxy2vpn import docker_ops
+
+    calls: list[tuple[str, str, bool]] = []
+
+    def fake_start(service, profile, force):
+        calls.append((service.name, profile.name, force))
+
+    monkeypatch.setattr(docker_ops, "start_vpn_service", fake_start)
+
+    asyncio.run(
+        fleet_manager._start_services_parallel(["testvpn1", "testvpn2"], force=False)
+    )
+
+    assert sorted(c[0] for c in calls) == ["testvpn1", "testvpn2"]
+    assert all(not c[2] for c in calls)
+
+
+def test_start_services_sequential_uses_helper(monkeypatch, fleet_manager):
+    from proxy2vpn import docker_ops
+
+    calls: list[tuple[str, str, bool]] = []
+
+    def fake_start(service, profile, force):
+        calls.append((service.name, profile.name, force))
+
+    monkeypatch.setattr(docker_ops, "start_vpn_service", fake_start)
+
+    asyncio.run(
+        fleet_manager._start_services_sequential(["testvpn1", "testvpn2"], force=True)
+    )
+
+    assert calls == [("testvpn1", "test", True), ("testvpn2", "test", True)]


### PR DESCRIPTION
## Summary
- add start_vpn_service for unified VPN container start logic
- use helper in fleet manager start routines and start_all_vpn_containers
- expand test coverage and add changelog entry

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f5bf148832f8f85bc3584af6181