### PR TITLE
Disable authentication for Gluetun control API

### DIFF
--- a/news/242.bugfix.md
+++ b/news/242.bugfix.md
@@ -1,0 +1,1 @@
+Fix 401 errors when querying the Gluetun control API by mounting a default authentication config that disables credentials for control routes.

--- a/src/proxy2vpn/config.py
+++ b/src/proxy2vpn/config.py
@@ -53,3 +53,23 @@ CONTROL_API_ENDPOINTS = {
     "ip": "/ip",
     "openvpn_status": "/openvpn/status",
 }
+
+# Path to the control server authentication configuration mounted into
+# each Gluetun container.  The configuration disables authentication for
+# a small set of non-sensitive routes used by proxy2vpn so the control
+# API can be queried without manual setup.
+CONTROL_AUTH_CONFIG_FILE: Path = Path("control-server-auth.toml")
+
+# Default content of the control server authentication configuration.
+# It declares a single role allowing access to the endpoints required by
+# proxy2vpn with ``auth = "none"`` so no credentials are needed.
+CONTROL_AUTH_CONFIG_TEMPLATE = """[[roles]]
+name = "proxy2vpn"
+auth = "none"
+routes = [
+  "GET /v1/status",
+  "GET /v1/ip",
+  "POST /v1/openvpn",
+  "PUT /v1/openvpn/status",
+]
+"""

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -12,7 +12,7 @@ from .compose_manager import ComposeManager
 from .diagnostics import DiagnosticAnalyzer, DiagnosticResult
 from .models import Profile, VPNService
 from .logging_utils import get_logger
-from . import ip_utils
+from . import config, ip_utils
 
 import docker
 from docker.models.containers import Container
@@ -171,6 +171,16 @@ def create_vpn_container(service: VPNService, profile: Profile) -> Container:
             "8888/tcp": service.port,
             "8000/tcp": ("127.0.0.1", service.control_port),
         }
+        auth_config = config.CONTROL_AUTH_CONFIG_FILE
+        if not auth_config.exists():
+            auth_config.parent.mkdir(parents=True, exist_ok=True)
+            auth_config.write_text(config.CONTROL_AUTH_CONFIG_TEMPLATE)
+        volumes = {
+            str(auth_config.resolve()): {
+                "bind": "/gluetun/auth/config.toml",
+                "mode": "ro",
+            }
+        }
         container = client.containers.create(
             profile.image,
             name=service.name,
@@ -181,6 +191,7 @@ def create_vpn_container(service: VPNService, profile: Profile) -> Container:
             cap_add=profile.cap_add,
             devices=profile.devices,
             network="proxy2vpn_network",
+            volumes=volumes,
         )
         logger.info(
             "vpn_container_created",


### PR DESCRIPTION
## Summary
- Mount a default Gluetun control server auth config that leaves required routes public
- Document the change in a news fragment

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ac43485448832f8d8c7c72124b23f4