### PR TITLE
refactor: centralize service status counting

### DIFF
--- a/news/300.feature.md
+++ b/news/300.feature.md
@@ -1,0 +1,1 @@
+Add helper to count service statuses and reuse in fleet status

--- a/src/proxy2vpn/docker_ops.py
+++ b/src/proxy2vpn/docker_ops.py
@@ -362,6 +362,17 @@ def get_container_by_service_name(service_name: str) -> Container | None:
         return None
 
 
+def get_service_status_counts(names: list[str]) -> tuple[int, int]:
+    """Return counts of running and stopped services for given names."""
+    containers = {c.name: c for c in get_vpn_containers(all=True)}
+    running = sum(
+        1
+        for name in names
+        if (container := containers.get(name)) and container.status == "running"
+    )
+    return running, len(names) - running
+
+
 def get_problematic_containers(all: bool = False) -> list[Container]:
     """Return containers that are not running properly."""
 

--- a/src/proxy2vpn/fleet_commands.py
+++ b/src/proxy2vpn/fleet_commands.py
@@ -391,21 +391,10 @@ def _display_fleet_services(fleet_status: dict, format: str):
 
 def _show_fleet_status_sync(service_names: list[str]):
     """Show basic fleet status without async operations"""
-    from .docker_ops import get_vpn_containers
+    from .docker_ops import get_service_status_counts
 
     try:
-        containers = {c.name: c for c in get_vpn_containers(all=True)}
-
-        running = 0
-        stopped = 0
-
-        for name in service_names:
-            container = containers.get(name)
-            if container and container.status == "running":
-                running += 1
-            else:
-                stopped += 1
-
+        running, stopped = get_service_status_counts(service_names)
         console.print(f"  • Running: {running}")
         console.print(f"  • Stopped: {stopped}")
 

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -398,3 +398,25 @@ def test_start_services_sequential_uses_helper(monkeypatch, fleet_manager):
     )
 
     assert calls == [("testvpn1", "test", True), ("testvpn2", "test", True)]
+
+
+def test_get_service_status_counts(monkeypatch):
+    from proxy2vpn.docker_ops import get_service_status_counts
+
+    class FakeContainer:
+        def __init__(self, name, status):
+            self.name = name
+            self.status = status
+
+    containers = [
+        FakeContainer("svc1", "running"),
+        FakeContainer("svc2", "exited"),
+    ]
+
+    monkeypatch.setattr(
+        "proxy2vpn.docker_ops.get_vpn_containers", lambda all=True: containers
+    )
+
+    running, stopped = get_service_status_counts(["svc1", "svc2", "svc3"])
+    assert running == 1
+    assert stopped == 2


### PR DESCRIPTION
## Summary
- add helper to compute running and stopped service counts
- use helper in fleet status display
- test service status helper

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68acada858dc832fa7d26d97719eae79