### PR TITLE
refactor: drop legacy provider flag from fleet plan

### DIFF
--- a/news/003.removal.md
+++ b/news/003.removal.md
@@ -1,0 +1,1 @@
+Drop the deprecated --provider flag from `fleet plan`; providers now come solely from profile env files.

--- a/src/proxy2vpn/adapters/fleet_commands.py
+++ b/src/proxy2vpn/adapters/fleet_commands.py
@@ -17,9 +17,6 @@ def fleet_plan(
     ctx: typer.Context,
     countries: str = typer.Option(..., help="Comma-separated country list"),
     profiles: str = typer.Option(..., help="Profile slots: acc1:2,acc2:8"),
-    provider: str = typer.Option(
-        None, help="Single provider (legacy mode, overrides profile providers)"
-    ),
     port_start: int = typer.Option(20000, help="Starting port number"),
     naming_template: str = typer.Option(
         "{provider}-{country}-{city}", help="Service naming template"
@@ -30,11 +27,7 @@ def fleet_plan(
         False, help="Ensure each service uses a unique city and server IP"
     ),
 ):
-    """Plan multi-provider VPN deployment based on profile providers.
-
-    NEW: Profiles can specify VPN_PROVIDER in their env files for automatic orchestration.
-    Use --provider to force all profiles to use a single provider (legacy mode).
-    """
+    """Plan multi-provider VPN deployment based on profile providers."""
 
     # Parse inputs
     country_list = [c.strip() for c in countries.split(",")]
@@ -52,20 +45,14 @@ def fleet_plan(
     )
     console.print(f"[blue]📊 Profile allocation: {profiles}[/blue]")
 
-    if provider:
-        console.print(
-            f"[yellow]⚠ Legacy mode: forcing all profiles to use {provider}[/yellow]"
-        )
-    else:
-        console.print(
-            "[green]🔧 Multi-provider mode: using VPN_PROVIDER from profile env files[/green]"
-        )
+    console.print(
+        "[green]🔧 Multi-provider mode: using VPN_PROVIDER from profile env files[/green]"
+    )
 
     # Create fleet configuration
     config_obj = FleetConfig(
         countries=country_list,
         profiles=profile_config,
-        provider=provider,
         port_start=port_start,
         naming_template=naming_template,
         unique_ips=unique_ips,
@@ -259,8 +246,7 @@ def _display_deployment_plan(
     plan: DeploymentPlan, profile_config: dict[str, int] | None = None
 ):
     """Display deployment plan in a formatted table"""
-
-    table = Table(title=f"🚀 Fleet Deployment Plan - {plan.provider}")
+    table = Table(title="🚀 Fleet Deployment Plan")
     table.add_column("Service", style="cyan")
     table.add_column("Profile", style="magenta")
     table.add_column("Location", style="green")
@@ -292,7 +278,8 @@ def _display_deployment_plan(
     # Show summary
     console.print("\n[bold]Summary:[/bold]")
     console.print(f"  • Total services: {len(plan.services)}")
-    console.print(f"  • Provider: {plan.provider}")
+    providers = ", ".join(sorted(plan.providers)) or "n/a"
+    console.print(f"  • Providers: {providers}")
 
     if profile_config:
         console.print("  • Profile allocation:")

--- a/src/proxy2vpn/adapters/fleet_manager.py
+++ b/src/proxy2vpn/adapters/fleet_manager.py
@@ -19,7 +19,6 @@ class FleetConfig:
 
     countries: list[str]  # ["Germany", "France", "Netherlands"]
     profiles: dict[str, int]  # {"acc1": 2, "acc2": 8} - profile slots
-    provider: str | None = None  # Optional single provider (legacy support)
     port_start: int = 20000
     control_port_start: int = 30000
     naming_template: str = "{provider}-{country}-{city}"
@@ -140,7 +139,7 @@ class FleetManager:
 
     def plan_deployment(self, config: FleetConfig) -> DeploymentPlan:
         """Create deployment plan with multi-provider orchestration based on profile providers."""
-        plan = DeploymentPlan(provider=config.provider)
+        plan = DeploymentPlan()
 
         # Load all profiles and validate they exist
         available_profiles = {p.name: p for p in self.compose_manager.list_profiles()}
@@ -152,19 +151,12 @@ class FleetManager:
         profile_providers: dict[str, list[str]] = {}
         for profile_name in config.profiles.keys():
             profile = available_profiles[profile_name]
+            try:
+                provider = profile.provider
+            except ValueError as e:
+                raise ValueError(f"Fleet planning failed: {e}") from e
 
-            # Use legacy single provider if specified, otherwise use profile provider
-            if config.provider:
-                provider = config.provider
-            else:
-                try:
-                    provider = profile.provider
-                except ValueError as e:
-                    raise ValueError(f"Fleet planning failed: {e}") from e
-
-            if provider not in profile_providers:
-                profile_providers[provider] = []
-            profile_providers[provider].append(profile_name)
+            profile_providers.setdefault(provider, []).append(profile_name)
 
         console.print(
             f"[blue]📋 Multi-provider deployment across {len(profile_providers)} providers[/blue]"

--- a/src/proxy2vpn/cli/commands/fleet.py
+++ b/src/proxy2vpn/cli/commands/fleet.py
@@ -9,7 +9,6 @@ app = HelpfulTyper(help="Manage VPN fleets across multiple cities")
 @app.command("plan")
 def plan(
     ctx: typer.Context,
-    provider: str = typer.Option("protonvpn", help="VPN provider"),
     countries: str = typer.Option(..., help="Comma-separated country list"),
     profiles: str = typer.Option(..., help="Profile slots: acc1:2,acc2:8"),
     port_start: int = typer.Option(20000, help="Starting port number"),
@@ -27,7 +26,6 @@ def plan(
 
     fleet_plan(
         ctx,
-        provider,
         countries,
         profiles,
         port_start,

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -26,8 +26,17 @@ def test_plan_deployment_basic_allocation(fleet_manager, monkeypatch):
 
     monkeypatch.setattr(fleet_manager.server_manager, "list_cities", fake_list_cities)
 
+    profiles = [
+        Profile(name="acc1", env_file="env.acc1"),
+        Profile(name="acc2", env_file="env.acc2"),
+    ]
+    for p in profiles:
+        p._provider = "prov"
+    monkeypatch.setattr(
+        fleet_manager.compose_manager, "list_profiles", lambda: profiles
+    )
+
     config = FleetConfig(
-        provider="prov",
         countries=["A", "B"],
         profiles={"acc1": 1, "acc2": 1},
         port_start=30000,
@@ -56,8 +65,13 @@ def test_plan_deployment_sanitizes_and_limits(fleet_manager, monkeypatch):
 
     monkeypatch.setattr(fleet_manager.server_manager, "list_cities", fake_list_cities)
 
+    profile = Profile(name="acc1", env_file="env.acc1")
+    profile._provider = "prov"
+    monkeypatch.setattr(
+        fleet_manager.compose_manager, "list_profiles", lambda: [profile]
+    )
+
     config = FleetConfig(
-        provider="prov",
         countries=["United States"],
         profiles={"acc1": 1},
         port_start=21000,
@@ -72,7 +86,7 @@ def test_plan_deployment_sanitizes_and_limits(fleet_manager, monkeypatch):
     assert service.port == 21000
 
 
-def test_plan_deployment_unique_ips(fleet_manager):
+def test_plan_deployment_unique_ips(fleet_manager, monkeypatch):
     fleet_manager.server_manager.data = {
         "version": 1,
         "protonvpn": {
@@ -104,8 +118,13 @@ def test_plan_deployment_unique_ips(fleet_manager):
             ]
         },
     }
+    profile = Profile(name="acc1", env_file="env.acc1")
+    profile._provider = "protonvpn"
+    monkeypatch.setattr(
+        fleet_manager.compose_manager, "list_profiles", lambda: [profile]
+    )
+
     config = FleetConfig(
-        provider="protonvpn",
         countries=["A", "B"],
         profiles={"acc1": 3},
         port_start=40000,
@@ -140,8 +159,13 @@ def test_plan_deployment_missing_profile(fleet_manager, monkeypatch):
 
     monkeypatch.setattr(fleet_manager.server_manager, "list_cities", fake_list_cities)
 
+    profile = Profile(name="acc1", env_file="env.acc1")
+    profile._provider = "prov"
+    monkeypatch.setattr(
+        fleet_manager.compose_manager, "list_profiles", lambda: [profile]
+    )
+
     config = FleetConfig(
-        provider="prov",
         countries=["A"],
         profiles={"missing": 1},
         port_start=30000,
@@ -502,48 +526,6 @@ def test_multi_provider_fleet_planning(tmp_path):
     assert any("expressvpn-" in name for name in service_names)
     assert any("nordvpn-" in name for name in service_names)
     assert any("protonvpn-" in name for name in service_names)
-
-
-def test_multi_provider_legacy_mode(tmp_path):
-    """Test legacy single-provider mode overrides profile providers."""
-    # Setup profiles with different providers
-    compose_path = tmp_path / "compose.yml"
-    ComposeManager.create_initial_compose(compose_path, force=True)
-    manager = ComposeManager(compose_path)
-
-    expressvpn_env = tmp_path / "expressvpn.env"
-    expressvpn_env.write_text(
-        "VPN_PROVIDER=expressvpn\nOPENVPN_USER=user\nOPENVPN_PASSWORD=pass\n"
-    )
-
-    nordvpn_env = tmp_path / "nordvpn.env"
-    nordvpn_env.write_text(
-        "VPN_PROVIDER=nordvpn\nOPENVPN_USER=user\nOPENVPN_PASSWORD=pass\n"
-    )
-
-    manager.add_profile(Profile(name="express-acc1", env_file=str(expressvpn_env)))
-    manager.add_profile(Profile(name="nord-acc1", env_file=str(nordvpn_env)))
-
-    fleet_manager = FleetManager(compose_file_path=compose_path)
-
-    def fake_list_cities(provider, country):
-        return {"Germany": ["Berlin"], "France": ["Paris"]}.get(country, [])
-
-    fleet_manager.server_manager.list_cities = fake_list_cities
-
-    # Test legacy mode - force all profiles to use protonvpn
-    config = FleetConfig(
-        countries=["Germany", "France"],
-        profiles={"express-acc1": 1, "nord-acc1": 1},
-        provider="protonvpn",  # Legacy mode override
-    )
-
-    plan = fleet_manager.plan_deployment(config)
-
-    # Verify legacy mode overrides profile providers
-    assert len(plan.providers) == 1
-    assert "protonvpn" in plan.providers
-    assert all(s.provider == "protonvpn" for s in plan.services)
 
 
 def test_profile_validation_during_fleet_planning(tmp_path):


### PR DESCRIPTION
## Summary
- remove deprecated `--provider` flag from `fleet plan`
- derive deployment providers solely from profile env files
- update tests and docs

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adbad2afdc832fb4f413b2772ccb35