### PR TITLE
feat: validate provider during profile creation

### DIFF
--- a/news/007.feature.md
+++ b/news/007.feature.md
@@ -1,0 +1,1 @@
+validate VPN provider during interactive profile creation

--- a/src/proxy2vpn/cli/commands/profile.py
+++ b/src/proxy2vpn/cli/commands/profile.py
@@ -12,6 +12,7 @@ from proxy2vpn.core.models import Profile, ServiceCredentials
 from proxy2vpn.common import abort
 from proxy2vpn.adapters.validators import sanitize_name, sanitize_path
 from proxy2vpn.adapters.logging_utils import get_logger
+from proxy2vpn.adapters import server_manager
 
 app = HelpfulTyper(help="Manage VPN profiles and apply them to services")
 logger = get_logger(__name__)
@@ -36,7 +37,19 @@ def create(
     console.print("[yellow]💡 Enter the required VPN credentials:[/yellow]")
 
     # Required fields
-    provider = typer.prompt("VPN Provider (e.g., expressvpn, nordvpn, protonvpn)")
+    provider = (
+        typer.prompt("VPN Provider (e.g., expressvpn, nordvpn, protonvpn)")
+        .strip()
+        .lower()
+    )
+
+    supported = server_manager.ServerManager().list_providers()
+    if provider not in supported:
+        abort(
+            f"Unsupported provider '{provider}'",
+            "Run 'proxy2vpn servers list-providers' to see supported providers",
+        )
+
     username = typer.prompt("VPN Username")
     password = typer.prompt("VPN Password", hide_input=True)
 

--- a/tests/test_profile_create_provider_validation.py
+++ b/tests/test_profile_create_provider_validation.py
@@ -1,0 +1,62 @@
+import pathlib
+
+from typer.testing import CliRunner
+
+from proxy2vpn.cli.main import app
+from proxy2vpn.adapters.compose_manager import ComposeManager
+from proxy2vpn.cli.commands import profile
+
+
+def _create_compose(tmp_path: pathlib.Path) -> pathlib.Path:
+    compose_path = tmp_path / "compose.yml"
+    ComposeManager.create_initial_compose(compose_path, force=True)
+    return compose_path
+
+
+def test_profile_create_rejects_unknown_provider(tmp_path, monkeypatch):
+    compose_path = _create_compose(tmp_path)
+    runner = CliRunner()
+
+    class DummyServerManager:
+        def list_providers(self):
+            return ["prov"]
+
+    monkeypatch.setattr(
+        profile.server_manager, "ServerManager", lambda: DummyServerManager()
+    )
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            app,
+            ["--compose-file", str(compose_path), "profile", "create", "test"],
+            input="bad\n",
+        )
+        assert result.exit_code != 0
+        assert not pathlib.Path("profiles/test.env").exists()
+
+
+def test_profile_create_accepts_supported_provider(tmp_path, monkeypatch):
+    compose_path = _create_compose(tmp_path)
+    runner = CliRunner()
+
+    class DummyServerManager:
+        def list_providers(self):
+            return ["prov"]
+
+    monkeypatch.setattr(
+        profile.server_manager, "ServerManager", lambda: DummyServerManager()
+    )
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            app,
+            ["--compose-file", str(compose_path), "profile", "create", "test"],
+            input="prov\nuser\npass\nn\nn\n",
+        )
+        assert result.exit_code == 0
+        env_file = pathlib.Path("profiles/test.env")
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "VPN_PROVIDER=prov" in content
+        assert "OPENVPN_USER=user" in content
+        assert "OPENVPN_PASSWORD=pass" in content


### PR DESCRIPTION
## Summary
- ensure `profile create` only accepts providers supported by gluetun
- test provider validation during profile creation

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68add4d89594832fa85e79591efdb149