### PR TITLE
feat: validate provider against server list

### DIFF
--- a/news/008.feature.md
+++ b/news/008.feature.md
@@ -1,0 +1,1 @@
+Validate VPN_PROVIDER against available server list during profile environment validation.

--- a/src/proxy2vpn/core/models.py
+++ b/src/proxy2vpn/core/models.py
@@ -284,14 +284,23 @@ class Profile(BaseModel):
         """
 
         from proxy2vpn.adapters.docker_ops import _load_env_file
+        from proxy2vpn.adapters import server_manager
 
         env_vars = _load_env_file(str(self._resolve_env_path()))
         errors: list[str] = []
 
-        if not env_vars.get("VPN_PROVIDER"):
+        provider = env_vars.get("VPN_PROVIDER")
+        if not provider:
             errors.append(
                 "VPN_PROVIDER is required (e.g., 'expressvpn', 'nordvpn', 'protonvpn')"
             )
+        else:
+            supported = server_manager.ServerManager().list_providers()
+            if provider.strip().lower() not in supported:
+                errors.append(
+                    f"Unsupported VPN_PROVIDER '{provider}'. "
+                    "Run 'proxy2vpn servers list-providers' to see supported providers"
+                )
 
         if not env_vars.get("OPENVPN_USER"):
             errors.append("OPENVPN_USER is required (your VPN account username)")

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -10,6 +10,7 @@ from proxy2vpn.adapters.fleet_manager import (
 )
 from proxy2vpn.adapters.compose_manager import ComposeManager
 from proxy2vpn.core.models import Profile, VPNService
+from proxy2vpn.adapters import server_manager
 
 
 @pytest.fixture
@@ -562,8 +563,15 @@ def test_profile_validation_during_fleet_planning(tmp_path):
         fleet_manager.plan_deployment(config)
 
 
-def test_profile_comprehensive_validation(tmp_path):
+def test_profile_comprehensive_validation(tmp_path, monkeypatch):
     """Test comprehensive profile validation covers all required fields."""
+
+    class DummyServerManager:
+        def list_providers(self):
+            return ["expressvpn", "nordvpn", "protonvpn"]
+
+    monkeypatch.setattr(server_manager, "ServerManager", lambda: DummyServerManager())
+
     # Test missing VPN_PROVIDER
     missing_provider_env = tmp_path / "missing_provider.env"
     missing_provider_env.write_text("OPENVPN_USER=user\nOPENVPN_PASSWORD=pass\n")
@@ -596,6 +604,16 @@ def test_profile_comprehensive_validation(tmp_path):
     assert any(
         "HTTPPROXY_PASSWORD is required when HTTPPROXY=on" in error for error in errors
     )
+
+    # Test invalid VPN provider
+    invalid_provider_env = tmp_path / "invalid_provider.env"
+    invalid_provider_env.write_text(
+        "VPN_PROVIDER=invalidvpn\nOPENVPN_USER=user\nOPENVPN_PASSWORD=pass\n"
+    )
+
+    profile = Profile(name="test", env_file=str(invalid_provider_env))
+    errors = profile.validate_env_file()
+    assert any("Unsupported VPN_PROVIDER" in error for error in errors)
 
     # Test valid profile passes validation
     valid_env = tmp_path / "valid.env"

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -9,6 +9,7 @@ from click.exceptions import Exit
 from proxy2vpn.adapters.compose_manager import ComposeManager
 from proxy2vpn.cli.main import app
 from proxy2vpn.cli.commands.profile import add as profile_add
+from proxy2vpn.adapters import server_manager
 
 
 def _create_test_compose(tmp_path: pathlib.Path) -> pathlib.Path:
@@ -25,6 +26,22 @@ def _cli_ctx(compose_path: pathlib.Path):
     ctx = typer.Context(command, obj={"compose_file": compose_path})
     with ctx:
         yield ctx
+
+
+class DummyServerManager:
+    def list_providers(self):
+        return [
+            "expressvpn",
+            "nordvpn",
+            "protonvpn",
+            "surfshark",
+            "mullvad",
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _patch_server_manager(monkeypatch):
+    monkeypatch.setattr(server_manager, "ServerManager", lambda: DummyServerManager())
 
 
 def test_profile_create_with_valid_env_file(tmp_path):


### PR DESCRIPTION
## Summary
- validate VPN_PROVIDER in profile env files against the cached server list
- cover invalid provider case in profile validation tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68add689fc60832f8fd977533d7c5252