### PR TITLE
feat: infer provider for vpn create from profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ uv run proxy2vpn <command> [args]
 
 # Common commands
 uv run proxy2vpn profile create myprofile profiles/myprofile.env
-proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn --location "New York"
+proxy2vpn vpn create vpn1 myprofile --port 8888 --location "New York"
 uv run proxy2vpn profile apply myprofile vpn1 --port 8888
 uv run proxy2vpn vpn start vpn1
 uv run proxy2vpn vpn list --diagnose

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ EOF
 
 # 3. Register the profile and create a VPN service
 proxy2vpn profile create production profiles/production.env
-proxy2vpn vpn create london-proxy production --port 8888 --provider protonvpn --location "United Kingdom"
+proxy2vpn vpn create london-proxy production --port 8888 --location "United Kingdom"
 
 # 4. Start and test your VPN
 proxy2vpn vpn start london-proxy
@@ -211,8 +211,8 @@ proxy2vpn fleet deploy --parallel
 ### Geo-location Testing
 ```bash
 # Test your app from different countries
-proxy2vpn vpn create us-east production --provider protonvpn --location "New York"
-proxy2vpn vpn create eu-west production --provider protonvpn --location "Amsterdam"
+proxy2vpn vpn create us-east production --location "New York"
+proxy2vpn vpn create eu-west production --location "Amsterdam"
 proxy2vpn vpn start --all
 ```
 
@@ -246,7 +246,7 @@ proxy2vpn vpn create dev-proxy dev-account --port 8888 --location "Netherlands"
 - `proxy2vpn profile apply PROFILE SERVICE [--port PORT]`
 
 ### VPN services
-- `proxy2vpn vpn create NAME PROFILE [--port PORT] [--provider PROVIDER] [--location LOCATION]`
+- `proxy2vpn vpn create NAME PROFILE [--port PORT] [--location LOCATION]`
 - `proxy2vpn vpn list [--diagnose] [--ips-only]`
 - `proxy2vpn vpn start [NAME | --all]`
 - `proxy2vpn vpn stop [NAME | --all]`

--- a/news/009.removal.md
+++ b/news/009.removal.md
@@ -1,0 +1,1 @@
+Remove `--provider` option from `vpn create`; provider is now inferred from the profile.

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -21,5 +21,5 @@ OPENVPN_PASSWORD=password
 
 2. Use the profile when creating services:
    ```bash
-   proxy2vpn vpn create vpn1 myprofile --port 8888 --provider protonvpn
+   proxy2vpn vpn create vpn1 myprofile --port 8888
    ```

--- a/src/proxy2vpn/cli/commands/vpn.py
+++ b/src/proxy2vpn/cli/commands/vpn.py
@@ -69,7 +69,6 @@ def create(
         callback=validate_port,
         help="Control port; 0 for auto",
     ),
-    provider: str = typer.Option(config.DEFAULT_PROVIDER),
     location: str = typer.Option("", help="Optional location, e.g. city"),
     force: bool = typer.Option(
         False, "--force", "-f", help="Ignore location validation"
@@ -79,12 +78,15 @@ def create(
 
     manager = ComposeManager.from_ctx(ctx)
     try:
-        manager.get_profile(profile)
+        prof = manager.get_profile(profile)
+        provider = prof.provider
     except KeyError:
         abort(
             f"Profile '{profile}' not found",
             "Create it with 'proxy2vpn profile create'",
         )
+    except ValueError as exc:
+        abort(str(exc))
     if port == 0:
         port = manager.next_available_port(config.DEFAULT_PORT_START)
     if control_port == 0:

--- a/tests/test_cli_location_validation.py
+++ b/tests/test_cli_location_validation.py
@@ -9,7 +9,7 @@ from proxy2vpn.adapters.compose_manager import ComposeManager
 def _copy_compose(tmp_path: pathlib.Path) -> pathlib.Path:
     src = pathlib.Path(__file__).parent / "test_compose.yml"
     env_path = tmp_path / "env.test"
-    env_path.write_text("KEY=value\n")
+    env_path.write_text("VPN_PROVIDER=prov\nKEY=value\n")
     dest = tmp_path / "compose.yml"
     text = src.read_text().replace("env.test", str(env_path))
     dest.write_text(text)
@@ -45,8 +45,6 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
             "test",
             "--port",
             "7777",
-            "--provider",
-            "prov",
             "--location",
             "Toronto,CA",
         ],
@@ -78,8 +76,6 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
             "test",
             "--port",
             "7778",
-            "--provider",
-            "prov",
             "--location",
             "Atlantis",
         ],
@@ -97,8 +93,6 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
             "test",
             "--port",
             "7778",
-            "--provider",
-            "prov",
             "--location",
             "Atlantis",
             "--force",


### PR DESCRIPTION
## Summary
- remove `--provider` flag from `vpn create` and pull provider from the chosen profile
- update docs and tests to reflect provider-less `vpn create`
- note change in changelog

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68add8485a94832fa2a445e58efa9551