### PR TITLE
feat: add control server diagnostics and CLI commands

### DIFF
--- a/news/010.feature.md
+++ b/news/010.feature.md
@@ -1,0 +1,2 @@
+- Integrated Gluetun control server checks into diagnostics
+- Added CLI commands for DNS status, updater status, and port forwarding

--- a/src/proxy2vpn/adapters/http_client.py
+++ b/src/proxy2vpn/adapters/http_client.py
@@ -214,6 +214,27 @@ class OpenVPNStatusResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
+class DNSStatusResponse(BaseModel):
+    """Response payload for the ``/dns/status`` endpoint."""
+
+    status: str
+    model_config = ConfigDict(extra="ignore")
+
+
+class UpdaterStatusResponse(BaseModel):
+    """Response payload for the ``/updater/status`` endpoint."""
+
+    status: str
+    model_config = ConfigDict(extra="ignore")
+
+
+class PortForwardResponse(BaseModel):
+    """Response payload for the ``/openvpn/portforwarded`` endpoint."""
+
+    port: int
+    model_config = ConfigDict(extra="ignore")
+
+
 class GluetunControlClient(HTTPClient):
     """Client for interacting with Gluetun's control API."""
 
@@ -260,3 +281,15 @@ class GluetunControlClient(HTTPClient):
         payload = {"status": "restarted"}
         data = await self.request("PUT", self.ENDPOINTS["openvpn_status"], json=payload)
         return OpenVPNStatusResponse(**data)
+
+    async def dns_status(self) -> DNSStatusResponse:
+        data = await self.get(self.ENDPOINTS["dns_status"])
+        return DNSStatusResponse(**data)
+
+    async def updater_status(self) -> UpdaterStatusResponse:
+        data = await self.get(self.ENDPOINTS["updater_status"])
+        return UpdaterStatusResponse(**data)
+
+    async def port_forwarded(self) -> PortForwardResponse:
+        data = await self.get(self.ENDPOINTS["port_forward"])
+        return PortForwardResponse(**data)

--- a/src/proxy2vpn/cli/commands/system.py
+++ b/src/proxy2vpn/cli/commands/system.py
@@ -127,6 +127,12 @@ def diagnose(
 
         assert container.name is not None  # Type narrowing after null check
         results = analyze_container_logs(container.name, lines=lines, analyzer=analyzer)
+        ports = container.attrs.get("NetworkSettings", {}).get("Ports", {})
+        port_info = ports.get("8000/tcp")
+        if port_info and port_info[0].get("HostPort"):
+            control_port = port_info[0].get("HostPort")
+            base_url = f"http://localhost:{control_port}/v1"
+            results.extend(analyzer.control_api_checks(base_url))
         logger.debug(
             "log_analysis_complete",
             extra={"container_name": container.name, "issues_found": len(results)},

--- a/src/proxy2vpn/cli/commands/vpn.py
+++ b/src/proxy2vpn/cli/commands/vpn.py
@@ -586,6 +586,54 @@ async def public_ip(
     console.print(ip.ip)
 
 
+@app.command("dns-status")
+@run_async
+async def dns_status(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., callback=sanitize_name),
+):
+    """Show DNS service status for SERVICE."""
+
+    base_url = _service_control_base_url(ctx, service)
+    from proxy2vpn.adapters import http_client
+
+    async with http_client.GluetunControlClient(base_url) as client:
+        status = await client.dns_status()
+    console.print(status.status)
+
+
+@app.command("updater-status")
+@run_async
+async def updater_status(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., callback=sanitize_name),
+):
+    """Show updater job status for SERVICE."""
+
+    base_url = _service_control_base_url(ctx, service)
+    from proxy2vpn.adapters import http_client
+
+    async with http_client.GluetunControlClient(base_url) as client:
+        status = await client.updater_status()
+    console.print(status.status)
+
+
+@app.command("port-forwarded")
+@run_async
+async def port_forwarded(
+    ctx: typer.Context,
+    service: str = typer.Argument(..., callback=sanitize_name),
+):
+    """Show port forwarded for SERVICE."""
+
+    base_url = _service_control_base_url(ctx, service)
+    from proxy2vpn.adapters import http_client
+
+    async with http_client.GluetunControlClient(base_url) as client:
+        pf = await client.port_forwarded()
+    console.print(str(pf.port))
+
+
 @app.command("restart-tunnel")
 @run_async
 async def restart_tunnel(

--- a/src/proxy2vpn/core/config.py
+++ b/src/proxy2vpn/core/config.py
@@ -52,6 +52,9 @@ CONTROL_API_ENDPOINTS = {
     "openvpn": "/openvpn",
     "ip": "/ip",
     "openvpn_status": "/openvpn/status",
+    "dns_status": "/dns/status",
+    "updater_status": "/updater/status",
+    "port_forward": "/openvpn/portforwarded",
 }
 
 # Path to the control server authentication configuration mounted into
@@ -71,5 +74,8 @@ routes = [
   "GET /v1/ip",
   "POST /v1/openvpn",
   "PUT /v1/openvpn/status",
+  "GET /v1/dns/status",
+  "GET /v1/updater/status",
+  "GET /v1/openvpn/portforwarded",
 ]
 """

--- a/src/proxy2vpn/core/services/diagnostics.py
+++ b/src/proxy2vpn/core/services/diagnostics.py
@@ -129,6 +129,91 @@ class DiagnosticAnalyzer:
                 )
             ]
 
+    def control_api_checks(self, base_url: str) -> list[DiagnosticResult]:
+        """Query the control API for service health."""
+
+        import asyncio
+        from proxy2vpn.adapters.http_client import GluetunControlClient
+
+        async def _query() -> list[DiagnosticResult]:
+            results: list[DiagnosticResult] = []
+            async with GluetunControlClient(base_url) as client:
+                try:
+                    dns = await client.dns_status()
+                    ok = dns.status == "running"
+                    results.append(
+                        DiagnosticResult(
+                            check="dns_status",
+                            passed=ok,
+                            message=f"dns={dns.status}",
+                            recommendation="Start DNS service" if not ok else "",
+                        )
+                    )
+                except Exception:
+                    results.append(
+                        DiagnosticResult(
+                            check="dns_status",
+                            passed=False,
+                            message="dns status unavailable",
+                            recommendation="Control server not reachable",
+                        )
+                    )
+
+                try:
+                    upd = await client.updater_status()
+                    ok = upd.status in {"completed", "running"}
+                    results.append(
+                        DiagnosticResult(
+                            check="updater_status",
+                            passed=ok,
+                            message=f"updater={upd.status}",
+                            recommendation="Updater not running" if not ok else "",
+                        )
+                    )
+                except Exception:
+                    results.append(
+                        DiagnosticResult(
+                            check="updater_status",
+                            passed=False,
+                            message="updater status unavailable",
+                            recommendation="Control server not reachable",
+                        )
+                    )
+
+                try:
+                    pf = await client.port_forwarded()
+                    ok = pf.port > 0
+                    results.append(
+                        DiagnosticResult(
+                            check="port_forward",
+                            passed=ok,
+                            message=f"port={pf.port}",
+                            recommendation="No port forwarded" if not ok else "",
+                        )
+                    )
+                except Exception:
+                    results.append(
+                        DiagnosticResult(
+                            check="port_forward",
+                            passed=False,
+                            message="port forward unavailable",
+                            recommendation="Control server not reachable",
+                        )
+                    )
+            return results
+
+        try:
+            return asyncio.run(_query())
+        except Exception:
+            return [
+                DiagnosticResult(
+                    check="control_api",
+                    passed=False,
+                    message="control API check failed",
+                    recommendation="Ensure control server is accessible.",
+                )
+            ]
+
     def analyze(
         self, log_lines: Iterable[str], port: int | None = None
     ) -> list[DiagnosticResult]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,10 @@ from proxy2vpn.adapters import docker_ops
 def test_system_diagnose_specific_container(monkeypatch):
     runner = CliRunner()
 
-    container = SimpleNamespace(name="vpn1")
+    container = SimpleNamespace(
+        name="vpn1",
+        attrs={"NetworkSettings": {"Ports": {"8000/tcp": [{"HostPort": "30000"}]}}},
+    )
     monkeypatch.setattr(docker_ops, "get_vpn_containers", lambda all=True: [container])
     monkeypatch.setattr(
         docker_ops, "get_problematic_containers", lambda all=True: [container]
@@ -27,6 +30,9 @@ def test_system_diagnose_specific_container(monkeypatch):
     )
     monkeypatch.setattr(
         diagnostics.DiagnosticAnalyzer, "health_score", lambda self, results: 100
+    )
+    monkeypatch.setattr(
+        diagnostics.DiagnosticAnalyzer, "control_api_checks", lambda self, base_url: []
     )
 
     result = runner.invoke(app, ["system", "diagnose", "vpn1"])

--- a/tests/test_cli_control.py
+++ b/tests/test_cli_control.py
@@ -26,6 +26,16 @@ class _Restart:
     status: str
 
 
+@dataclass
+class _SimpleStatus:
+    status: str
+
+
+@dataclass
+class _Port:
+    port: int
+
+
 class DummyClient:
     def __init__(self, base_url):
         self.base_url = base_url
@@ -44,6 +54,15 @@ class DummyClient:
 
     async def restart_tunnel(self):
         return _Restart(status="restarted")
+
+    async def dns_status(self):
+        return _SimpleStatus(status="running")
+
+    async def updater_status(self):
+        return _SimpleStatus(status="completed")
+
+    async def port_forwarded(self):
+        return _Port(port=1234)
 
 
 def test_vpn_status_uses_localhost(monkeypatch):
@@ -94,6 +113,66 @@ def test_vpn_restart_tunnel_uses_localhost(monkeypatch):
     result = runner.invoke(
         app,
         ["--compose-file", str(COMPOSE_FILE), "vpn", "restart-tunnel", "testvpn1"],
+    )
+    assert result.exit_code == 0
+    assert called["base_url"] == "http://localhost:30000/v1"
+
+
+def test_vpn_dns_status_uses_localhost(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake_client(base_url):
+        called["base_url"] = base_url
+        return DummyClient(base_url)
+
+    monkeypatch.setattr(http_client, "GluetunControlClient", fake_client)
+
+    result = runner.invoke(
+        app,
+        ["--compose-file", str(COMPOSE_FILE), "vpn", "dns-status", "testvpn1"],
+    )
+    assert result.exit_code == 0
+    assert called["base_url"] == "http://localhost:30000/v1"
+
+
+def test_vpn_updater_status_uses_localhost(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake_client(base_url):
+        called["base_url"] = base_url
+        return DummyClient(base_url)
+
+    monkeypatch.setattr(http_client, "GluetunControlClient", fake_client)
+
+    result = runner.invoke(
+        app,
+        ["--compose-file", str(COMPOSE_FILE), "vpn", "updater-status", "testvpn1"],
+    )
+    assert result.exit_code == 0
+    assert called["base_url"] == "http://localhost:30000/v1"
+
+
+def test_vpn_port_forwarded_uses_localhost(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake_client(base_url):
+        called["base_url"] = base_url
+        return DummyClient(base_url)
+
+    monkeypatch.setattr(http_client, "GluetunControlClient", fake_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "--compose-file",
+            str(COMPOSE_FILE),
+            "vpn",
+            "port-forwarded",
+            "testvpn1",
+        ],
     )
     assert result.exit_code == 0
     assert called["base_url"] == "http://localhost:30000/v1"

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -9,6 +9,9 @@ from proxy2vpn.adapters.http_client import (
     OpenVPNResponse,
     IPResponse,
     OpenVPNStatusResponse,
+    DNSStatusResponse,
+    UpdaterStatusResponse,
+    PortForwardResponse,
     StatusResponse,
 )
 
@@ -87,3 +90,51 @@ def test_restart_tunnel_puts_status(monkeypatch):
     assert called["method"] == "PUT"
     assert called["path"] == GluetunControlClient.ENDPOINTS["openvpn_status"]
     assert called["json"] == {"status": "restarted"}
+
+
+def test_dns_status_calls_correct_path(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_request(self, method, path, **kwargs):
+        called["method"] = method
+        called["path"] = path
+        return {"status": "running"}
+
+    client = GluetunControlClient(BASE_URL)
+    monkeypatch.setattr(GluetunControlClient, "request", fake_request)
+    result = asyncio.run(client.dns_status())
+    assert result == DNSStatusResponse(status="running")
+    assert called["method"] == "GET"
+    assert called["path"] == GluetunControlClient.ENDPOINTS["dns_status"]
+
+
+def test_updater_status_calls_correct_path(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_request(self, method, path, **kwargs):
+        called["method"] = method
+        called["path"] = path
+        return {"status": "completed"}
+
+    client = GluetunControlClient(BASE_URL)
+    monkeypatch.setattr(GluetunControlClient, "request", fake_request)
+    result = asyncio.run(client.updater_status())
+    assert result == UpdaterStatusResponse(status="completed")
+    assert called["method"] == "GET"
+    assert called["path"] == GluetunControlClient.ENDPOINTS["updater_status"]
+
+
+def test_port_forwarded_calls_correct_path(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_request(self, method, path, **kwargs):
+        called["method"] = method
+        called["path"] = path
+        return {"port": 8888}
+
+    client = GluetunControlClient(BASE_URL)
+    monkeypatch.setattr(GluetunControlClient, "request", fake_request)
+    result = asyncio.run(client.port_forwarded())
+    assert result == PortForwardResponse(port=8888)
+    assert called["method"] == "GET"
+    assert called["path"] == GluetunControlClient.ENDPOINTS["port_forward"]

--- a/tests/test_gluetun_control_client.py
+++ b/tests/test_gluetun_control_client.py
@@ -7,6 +7,9 @@ from proxy2vpn.adapters.http_client import (
     IPResponse,
     OpenVPNResponse,
     OpenVPNStatusResponse,
+    DNSStatusResponse,
+    UpdaterStatusResponse,
+    PortForwardResponse,
     StatusResponse,
 )
 
@@ -75,6 +78,48 @@ def test_restart_tunnel_puts_status(monkeypatch):
     assert called["method"] == "PUT"
     assert called["path"] == GluetunControlClient.ENDPOINTS["openvpn_status"]
     assert called["json"] == {"status": "restarted"}
+
+
+def test_dns_status_calls_correct_path(monkeypatch):
+    called = {}
+
+    async def fake_get(self, path, **kwargs):  # pragma: no cover - simple mock
+        called["path"] = path
+        return {"status": "running"}
+
+    monkeypatch.setattr(HTTPClient, "get", fake_get)
+    client = GluetunControlClient(BASE_URL)
+    result = asyncio.run(client.dns_status())
+    assert result == DNSStatusResponse(status="running")
+    assert called["path"] == GluetunControlClient.ENDPOINTS["dns_status"]
+
+
+def test_updater_status_calls_correct_path(monkeypatch):
+    called = {}
+
+    async def fake_get(self, path, **kwargs):  # pragma: no cover - simple mock
+        called["path"] = path
+        return {"status": "completed"}
+
+    monkeypatch.setattr(HTTPClient, "get", fake_get)
+    client = GluetunControlClient(BASE_URL)
+    result = asyncio.run(client.updater_status())
+    assert result == UpdaterStatusResponse(status="completed")
+    assert called["path"] == GluetunControlClient.ENDPOINTS["updater_status"]
+
+
+def test_port_forwarded_calls_correct_path(monkeypatch):
+    called = {}
+
+    async def fake_get(self, path, **kwargs):  # pragma: no cover - simple mock
+        called["path"] = path
+        return {"port": 9999}
+
+    monkeypatch.setattr(HTTPClient, "get", fake_get)
+    client = GluetunControlClient(BASE_URL)
+    result = asyncio.run(client.port_forwarded())
+    assert result == PortForwardResponse(port=9999)
+    assert called["path"] == GluetunControlClient.ENDPOINTS["port_forward"]
 
 
 def test_auth_from_env(monkeypatch):


### PR DESCRIPTION
## Summary
- add DNS, updater, and port forwarding endpoints to control client
- expose new CLI commands for DNS status, updater status, and port forwarding
- integrate control server checks into system diagnostics

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68addd0dd4c4832fb9a58fb96af92484