### PR TITLE
fix: respect profile provider during fleet planning

### DIFF
--- a/news/012.bugfix.md
+++ b/news/012.bugfix.md
@@ -1,0 +1,1 @@
+fix fleet plan to allocate profiles only to matching providers

--- a/src/proxy2vpn/adapters/profile_allocator.py
+++ b/src/proxy2vpn/adapters/profile_allocator.py
@@ -55,25 +55,36 @@ class ProfileAllocator:
         )
 
     def get_next_available(
-        self, profile_config: dict[str, int] | None = None
+        self, allowed_profiles: dict[str, int] | None = None
     ) -> ProfileSlot | None:
-        """Get next available profile slot using round-robin with load balancing"""
-        if profile_config and not self.slots:
-            self.setup_profiles(profile_config)
+        """Get next available profile slot using round-robin with load balancing.
 
-        # Find profiles with available slots
-        available_profiles = [
-            slot for slot in self.slots.values() if slot.available_slots > 0
-        ]
+        If ``allowed_profiles`` is provided, selection is restricted to those
+        profile names. This is used when planning services for a specific VPN
+        provider so that slots from other providers are not allocated.
+        """
+        if allowed_profiles and not self.slots:
+            self.setup_profiles(allowed_profiles)
 
-        if not available_profiles:
+        if allowed_profiles:
+            candidates = [
+                self.slots[name]
+                for name in allowed_profiles.keys()
+                if name in self.slots and self.slots[name].available_slots > 0
+            ]
+        else:
+            candidates = [
+                slot for slot in self.slots.values() if slot.available_slots > 0
+            ]
+
+        if not candidates:
             logger.warning("No profile slots available")
             console.print("[yellow]⚠️ No profile slots available[/yellow]")
             return None
 
         # Round-robin with load balancing: choose profile with lowest utilization
         # This ensures even distribution across profiles
-        best_profile = min(available_profiles, key=lambda p: p.utilization_ratio)
+        best_profile = min(candidates, key=lambda p: p.utilization_ratio)
 
         logger.debug(
             f"Selected profile {best_profile.name} "

--- a/tests/test_fleet_manager.py
+++ b/tests/test_fleet_manager.py
@@ -529,6 +529,52 @@ def test_multi_provider_fleet_planning(tmp_path):
     assert any("protonvpn-" in name for name in service_names)
 
 
+def test_fleet_plan_respects_profile_providers(tmp_path):
+    """Ensure fleet planning allocates profiles matching provider."""
+    compose_path = tmp_path / "compose.yml"
+    ComposeManager.create_initial_compose(compose_path, force=True)
+    manager = ComposeManager(compose_path)
+
+    express_env = tmp_path / "express.env"
+    express_env.write_text(
+        "VPN_SERVICE_PROVIDER=expressvpn\nOPENVPN_USER=u\nOPENVPN_PASSWORD=p\n"
+    )
+    nord_env = tmp_path / "nord.env"
+    nord_env.write_text(
+        "VPN_SERVICE_PROVIDER=nordvpn\nOPENVPN_USER=u\nOPENVPN_PASSWORD=p\n"
+    )
+
+    manager.add_profile(Profile(name="express", env_file=str(express_env)))
+    manager.add_profile(Profile(name="nord", env_file=str(nord_env)))
+
+    fleet_manager = FleetManager(compose_file_path=compose_path)
+
+    def fake_list_cities(provider, country):
+        data = {
+            "expressvpn": {"Germany": ["Frankfurt", "Berlin"]},
+            "nordvpn": {"Germany": ["Hamburg"]},
+        }
+        return data.get(provider, {}).get(country, [])
+
+    fleet_manager.server_manager.list_cities = fake_list_cities
+
+    config = FleetConfig(
+        countries=["Germany"],
+        profiles={"express": 2, "nord": 1},
+        port_start=10000,
+    )
+
+    plan = fleet_manager.plan_deployment(config)
+
+    express_services = [s for s in plan.services if s.provider == "expressvpn"]
+    nord_services = [s for s in plan.services if s.provider == "nordvpn"]
+
+    assert len(express_services) == 2
+    assert all(s.profile == "express" for s in express_services)
+    assert len(nord_services) == 1
+    assert all(s.profile == "nord" for s in nord_services)
+
+
 def test_profile_validation_during_fleet_planning(tmp_path):
     """Test that fleet planning fails fast when profiles have missing VPN_SERVICE_PROVIDER."""
     compose_path = tmp_path / "compose.yml"


### PR DESCRIPTION
## Summary
- ensure profile allocator only selects slots from matching providers during fleet planning
- cover multi-provider allocation with a regression test
- document fleet planning fix

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ade123de50832fb585ac02fdbd6028