### PR TITLE
fix: place profiles before services in compose

### DIFF
--- a/news/151.bugfix.md
+++ b/news/151.bugfix.md
@@ -1,0 +1,1 @@
+Ensure profile definitions are placed before the services section in generated compose files.

--- a/src/proxy2vpn/adapters/compose_manager.py
+++ b/src/proxy2vpn/adapters/compose_manager.py
@@ -220,7 +220,10 @@ class ComposeManager:
         anchor_map = CommentedMap(profile.to_anchor())
         # Ensure the expected anchor so validators and merges work nicely
         anchor_map.yaml_set_anchor(f"vpn-base-{profile.name}", always_dump=True)
-        self.data[key] = anchor_map
+        # Insert profile definition before services so profiles stay at the top
+        keys = list(self.data.keys())
+        insert_at = keys.index("services") if "services" in self.data else len(keys)
+        self.data.insert(insert_at, key, anchor_map)
         self.save()
 
     def remove_profile(self, name: str) -> None:

--- a/tests/test_compose_manager.py
+++ b/tests/test_compose_manager.py
@@ -37,6 +37,17 @@ def test_profile_management(tmp_path):
     assert "new" not in {p.name for p in manager.list_profiles()}
 
 
+def test_profile_inserted_before_services(tmp_path):
+    compose_path = tmp_path / "compose.yml"
+    ComposeManager.create_initial_compose(compose_path, force=True)
+    manager = ComposeManager(compose_path)
+    env_path = tmp_path / "env.top"
+    env_path.write_text("KEY=value\n")
+    manager.add_profile(Profile(name="top", env_file=str(env_path)))
+    content = compose_path.read_text()
+    assert content.index("x-vpn-base-top:") < content.index("services:")
+
+
 def test_add_and_remove_service(tmp_path):
     compose_path = _copy_compose(tmp_path)
     manager = ComposeManager(compose_path)


### PR DESCRIPTION
## Summary
- keep profile definitions at the top of generated compose files
- test profile order to prevent regressions

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ade6d99144832f84c938e403bac489