### PR TITLE
feat: mount control server auth config in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ proxy2vpn vpn list --diagnose
 
 **Docker Integration**: All containers use consistent labeling and networking, making them easy to integrate with existing Docker workflows and monitoring tools.
 
+### Control server authentication
+
+To enable authenticated access to the Gluetun control API, create an auth
+configuration file such as:
+
+```toml
+[[roles]]
+name = "qbittorrent"
+routes = ["GET /v1/openvpn/portforwarded"]
+auth = "basic"
+username = "myusername"
+password = "mypassword"
+```
+
+Bind mount this file to `/gluetun/auth/config.toml` (or set a custom path via
+the `HTTP_CONTROL_SERVER_AUTH_CONFIG_FILEPATH` environment variable) and restart
+the container for the configuration to take effect.
+
 ## Enterprise Fleet Management
 
 **The real power of Proxy2VPN**: Deploy and manage dozens of VPN endpoints across the globe like infrastructure, not individual connections.

--- a/news/152.feature.md
+++ b/news/152.feature.md
@@ -1,0 +1,1 @@
+Mount control server auth config in compose

--- a/src/proxy2vpn/core/models.py
+++ b/src/proxy2vpn/core/models.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 from proxy2vpn.adapters.compose_utils import parse_env, iter_port_mappings
+from proxy2vpn.core import config
 
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -216,11 +217,14 @@ class VPNService(BaseModel):
                 labels["vpn.httpproxy_user"] = self.credentials.httpproxy_user
             if self.credentials.httpproxy_password:
                 labels["vpn.httpproxy_password"] = self.credentials.httpproxy_password
-
+        volumes = [
+            f"{config.CONTROL_AUTH_CONFIG_FILE}:/gluetun/auth/config.toml:ro",
+        ]
         return {
             "ports": ports,
             "environment": env_list,
             "labels": labels,
+            "volumes": volumes,
         }
 
 

--- a/tests/test_compose_manager.py
+++ b/tests/test_compose_manager.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 
 from proxy2vpn.adapters.compose_manager import ComposeManager
+from proxy2vpn.core import config
 from proxy2vpn.core.models import Profile, VPNService
 
 
@@ -77,6 +78,10 @@ def test_add_and_remove_service(tmp_path):
     compose_text = compose_path.read_text()
     assert "vpn3:" in compose_text
     assert "<<: *vpn-base-test" in compose_text
+    assert (
+        f"{config.CONTROL_AUTH_CONFIG_FILE}:/gluetun/auth/config.toml:ro"
+        in compose_text
+    )
     manager.remove_service("vpn3")
     assert "vpn3" not in {s.name for s in manager.list_services()}
 
@@ -115,6 +120,10 @@ def test_add_service_after_init(tmp_path):
     assert "image: qmcgaw/gluetun" in compose_text  # from profile
     assert "0.0.0.0:12345:8888/tcp" in compose_text  # from service
     assert "127.0.0.1:30003:8000/tcp" in compose_text  # from service
+    assert (
+        f"{config.CONTROL_AUTH_CONFIG_FILE}:/gluetun/auth/config.toml:ro"
+        in compose_text
+    )
 
     # Verify the service can be loaded back correctly
     loaded_service = manager.get_service("vpn1")


### PR DESCRIPTION
## Summary
- mount control server auth config in generated compose services
- document how to configure authenticated control API

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ade8cfd584832fa13a37e18366c07d