### PR TITLE
feat: split profile delete and remove commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ proxy2vpn vpn create dev-proxy dev-account --port 8888 --location "Netherlands"
 ### Profiles
 - `proxy2vpn profile create NAME ENV_FILE`
 - `proxy2vpn profile list`
+- `proxy2vpn profile remove NAME`
 - `proxy2vpn profile delete NAME`
 - `proxy2vpn profile apply PROFILE SERVICE [--port PORT]`
 

--- a/news/153.feature.md
+++ b/news/153.feature.md
@@ -1,0 +1,1 @@
+Rename `profile delete` to `profile remove` and introduce `profile delete` to remove profile environment files.

--- a/src/proxy2vpn/cli/commands/profile.py
+++ b/src/proxy2vpn/cli/commands/profile.py
@@ -157,13 +157,13 @@ def list_profiles(ctx: typer.Context):
     console.print(table)
 
 
-@app.command("delete")
-def delete(
+@app.command("remove")
+def remove(
     ctx: typer.Context,
     name: str = typer.Argument(..., callback=sanitize_name),
     force: bool = typer.Option(False, "--force", "-f", help="Do not prompt"),
 ):
-    """Delete a profile by NAME."""
+    """Remove a profile from the compose file."""
 
     compose_file: Path = ctx.obj.get("compose_file", config.COMPOSE_FILE)
     manager = ComposeManager(compose_file)
@@ -172,9 +172,29 @@ def delete(
     except KeyError:
         abort(f"Profile '{name}' not found")
     if not force:
-        typer.confirm(f"Delete profile '{name}'?", abort=True)
+        typer.confirm(f"Remove profile '{name}'?", abort=True)
     manager.remove_profile(name)
-    console.print(f"[green]✓[/green] Profile '{name}' deleted.")
+    console.print(f"[green]✓[/green] Profile '{name}' removed from compose.")
+
+
+@app.command("delete")
+def delete(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., callback=sanitize_name),
+    force: bool = typer.Option(False, "--force", "-f", help="Do not prompt"),
+):
+    """Delete a profile's environment file."""
+
+    env_file_path = Path("profiles") / f"{name}.env"
+    if not env_file_path.exists():
+        abort(f"Environment file '{env_file_path}' not found")
+    if not force:
+        typer.confirm(
+            f"Delete environment file '{env_file_path}'?",
+            abort=True,
+        )
+    env_file_path.unlink()
+    console.print(f"[green]✓[/green] Environment file '{env_file_path}' deleted.")
 
 
 @app.command("apply")

--- a/src/proxy2vpn/cli/typer_ext.py
+++ b/src/proxy2vpn/cli/typer_ext.py
@@ -347,7 +347,7 @@ class HelpfulTyper(typer.Typer):
             examples = [
                 f"{command_path} create myprofile --env-file /path/to/.env",
                 f"{command_path} list",
-                f"{command_path} delete myprofile",
+                f"{command_path} remove myprofile",
                 f"{command_path} apply myprofile myservice",
             ]
         elif "servers" in command_path:

--- a/tests/test_profile_remove_delete.py
+++ b/tests/test_profile_remove_delete.py
@@ -1,0 +1,50 @@
+import pathlib
+from contextlib import contextmanager
+
+import typer
+
+from proxy2vpn.adapters.compose_manager import ComposeManager
+from proxy2vpn.cli.main import app
+from proxy2vpn.cli.commands.profile import (
+    delete as profile_delete,
+    remove as profile_remove,
+)
+
+
+def _copy_compose(tmp_path: pathlib.Path) -> pathlib.Path:
+    src = pathlib.Path(__file__).parent / "test_compose.yml"
+    env_path = tmp_path / "env.test"
+    env_path.write_text("KEY=value\n")
+    dest = tmp_path / "compose.yml"
+    text = src.read_text().replace("env.test", str(env_path))
+    dest.write_text(text)
+    return dest
+
+
+@contextmanager
+def _cli_ctx(compose_path: pathlib.Path):
+    command = typer.main.get_command(app)
+    ctx = typer.Context(command, obj={"compose_file": compose_path})
+    with ctx:
+        yield ctx
+
+
+def test_profile_remove(tmp_path):
+    compose_path = _copy_compose(tmp_path)
+    with _cli_ctx(compose_path) as ctx:
+        profile_remove(ctx, "test", force=True)
+    manager = ComposeManager(compose_path)
+    profiles = {p.name for p in manager.list_profiles()}
+    assert "test" not in profiles
+
+
+def test_profile_delete_env(tmp_path, monkeypatch):
+    compose_path = _copy_compose(tmp_path)
+    env_dir = tmp_path / "profiles"
+    env_dir.mkdir()
+    env_file = env_dir / "test.env"
+    env_file.write_text("KEY=value\n")
+    monkeypatch.chdir(tmp_path)
+    with _cli_ctx(compose_path) as ctx:
+        profile_delete(ctx, "test", force=True)
+    assert not env_file.exists()


### PR DESCRIPTION
## Summary
- rename `profile delete` to `profile remove`
- add `profile delete` command to remove profile env files with confirmation
- adjust docs, examples and tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adeabd9b94832f9916f1674732ea71