### PR TITLE
feat: add VPN type option for profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ uv run proxy2vpn fleet rotate --dry-run
 Profile environment files (e.g., profiles/myprofile.env) have comprehensive validation:
 ```bash
 # Required fields (validated during profile creation)
+VPN_TYPE=openvpn
 VPN_SERVICE_PROVIDER=expressvpn
 OPENVPN_USER=your_vpn_username
 OPENVPN_PASSWORD=your_vpn_password
@@ -74,8 +75,9 @@ HTTPPROXY_PASSWORD=your_proxy_password
 
 **Validation Rules**:
 - `VPN_SERVICE_PROVIDER` - Required, must match supported gluetun provider
-- `OPENVPN_USER` - Required, your VPN account username
-- `OPENVPN_PASSWORD` - Required, your VPN account password  
+- `VPN_TYPE` - Optional, `openvpn` (default) or `wireguard`
+- `OPENVPN_USER` - Required when `VPN_TYPE=openvpn`
+- `OPENVPN_PASSWORD` - Required when `VPN_TYPE=openvpn`
 - `HTTPPROXY_USER/PASSWORD` - Required only if `HTTPPROXY=on`
 
 Profile creation fails fast with clear error messages if any required fields are missing.
@@ -107,7 +109,7 @@ All VPN containers use the `qmcgaw/gluetun` image with:
 
 ### Configuration System
 - **compose.yml**: Single source of truth for all state (services, profiles as YAML anchors)
-- **profiles/*.env**: VPN credentials (OPENVPN_USER, OPENVPN_PASSWORD) referenced by profiles
+- **profiles/*.env**: VPN settings (VPN_TYPE, OPENVPN_USER, OPENVPN_PASSWORD) referenced by profiles
 - **~/.cache/proxy2vpn/**: Server list cache with TTL management
 - **pyproject.toml**: Project configuration, dependencies, and towncrier settings
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ proxy2vpn system init
 # 2. Create your first profile with VPN credentials (all fields required)
 mkdir -p profiles
 cat <<'EOF' > profiles/production.env
+VPN_TYPE=openvpn
 VPN_SERVICE_PROVIDER=protonvpn
 OPENVPN_USER=your_protonvpn_username
 OPENVPN_PASSWORD=your_protonvpn_password
@@ -130,6 +131,7 @@ the container for the configuration to take effect.
 ```bash
 # Create profiles with provider information
 cat <<'EOF' > profiles/expressvpn-main.env
+VPN_TYPE=openvpn
 VPN_SERVICE_PROVIDER=expressvpn
 OPENVPN_USER=your_expressvpn_username
 OPENVPN_PASSWORD=your_expressvpn_password
@@ -139,6 +141,7 @@ HTTPPROXY_PASSWORD=proxy_pass
 EOF
 
 cat <<'EOF' > profiles/nordvpn-backup.env
+VPN_TYPE=openvpn
 VPN_SERVICE_PROVIDER=nordvpn
 OPENVPN_USER=your_nordvpn_username
 OPENVPN_PASSWORD=your_nordvpn_password

--- a/news/155.feature.md
+++ b/news/155.feature.md
@@ -1,0 +1,1 @@
+Add support for optional `VPN_TYPE` in profile environment files with validation for `openvpn` or `wireguard` (default `openvpn`).

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -8,9 +8,13 @@ registered with the CLI so it can be referenced when creating VPN services.
 Each profile file uses simple `KEY=value` pairs, for example:
 
 ```
+VPN_TYPE=openvpn
+VPN_SERVICE_PROVIDER=expressvpn
 OPENVPN_USER=username
 OPENVPN_PASSWORD=password
 ```
+
+`VPN_TYPE` may be `openvpn` or `wireguard` and defaults to `openvpn` if omitted.
 
 ## Usage
 

--- a/src/proxy2vpn/cli/commands/profile.py
+++ b/src/proxy2vpn/cli/commands/profile.py
@@ -50,8 +50,18 @@ def create(
             "Run 'proxy2vpn servers list-providers' to see supported providers",
         )
 
-    username = typer.prompt("VPN Username")
-    password = typer.prompt("VPN Password", hide_input=True)
+    vpn_type = typer.prompt("VPN type", default="openvpn").strip().lower()
+    if vpn_type not in ("openvpn", "wireguard"):
+        abort(
+            f"Unsupported VPN type '{vpn_type}'",
+            "Use 'openvpn' or 'wireguard'",
+        )
+
+    username = ""
+    password = ""
+    if vpn_type == "openvpn":
+        username = typer.prompt("VPN Username")
+        password = typer.prompt("VPN Password", hide_input=True)
 
     # Optional HTTP proxy
     enable_proxy = typer.confirm("Enable HTTP proxy?", default=False)
@@ -66,11 +76,14 @@ def create(
     env_file_path.parent.mkdir(exist_ok=True)
 
     # Create the environment file
-    env_content = [
-        f"VPN_SERVICE_PROVIDER={provider}",
-        f"OPENVPN_USER={username}",
-        f"OPENVPN_PASSWORD={password}",
-    ]
+    env_content = [f"VPN_TYPE={vpn_type}", f"VPN_SERVICE_PROVIDER={provider}"]
+    if vpn_type == "openvpn":
+        env_content.extend(
+            [
+                f"OPENVPN_USER={username}",
+                f"OPENVPN_PASSWORD={password}",
+            ]
+        )
 
     if enable_proxy:
         env_content.extend(
@@ -119,6 +132,7 @@ def add(
         for error in validation_errors:
             console.print(f"[red]  • {error}[/red]")
         console.print("\n[yellow]💡 Example valid profile:[/yellow]")
+        console.print("[green]VPN_TYPE=openvpn[/green]")
         console.print("[green]VPN_SERVICE_PROVIDER=expressvpn[/green]")
         console.print("[green]OPENVPN_USER=your_username[/green]")
         console.print("[green]OPENVPN_PASSWORD=your_password[/green]")

--- a/src/proxy2vpn/core/models.py
+++ b/src/proxy2vpn/core/models.py
@@ -238,6 +238,7 @@ class Profile(BaseModel):
     devices: list[str] = Field(default_factory=lambda: ["/dev/net/tun:/dev/net/tun"])
 
     _provider: str | None = PrivateAttr(default=None)
+    _vpn_type: str | None = PrivateAttr(default=None)
     _base_dir: Path | None = PrivateAttr(default=None)
 
     model_config = ConfigDict(validate_assignment=True)
@@ -281,6 +282,14 @@ class Profile(BaseModel):
             )
         return self._provider
 
+    @property
+    def vpn_type(self) -> str:
+        """Get VPN type from the environment file, defaulting to openvpn."""
+
+        if self._vpn_type is None:
+            self._load_vpn_type_from_env()
+        return self._vpn_type or "openvpn"
+
     def validate_env_file(self) -> list[str]:
         """Validate all required fields in the profile's environment file.
 
@@ -292,6 +301,10 @@ class Profile(BaseModel):
 
         env_vars = _load_env_file(str(self._resolve_env_path()))
         errors: list[str] = []
+
+        vpn_type = env_vars.get("VPN_TYPE", "openvpn").strip().lower()
+        if vpn_type not in ("openvpn", "wireguard"):
+            errors.append("VPN_TYPE must be 'openvpn' or 'wireguard'")
 
         provider = env_vars.get("VPN_SERVICE_PROVIDER")
         if not provider:
@@ -306,11 +319,14 @@ class Profile(BaseModel):
                     "Run 'proxy2vpn servers list-providers' to see supported providers"
                 )
 
-        if not env_vars.get("OPENVPN_USER"):
-            errors.append("OPENVPN_USER is required (your VPN account username)")
+        if vpn_type == "openvpn":
+            if not env_vars.get("OPENVPN_USER"):
+                errors.append("OPENVPN_USER is required (your VPN account username)")
 
-        if not env_vars.get("OPENVPN_PASSWORD"):
-            errors.append("OPENVPN_PASSWORD is required (your VPN account password)")
+            if not env_vars.get("OPENVPN_PASSWORD"):
+                errors.append(
+                    "OPENVPN_PASSWORD is required (your VPN account password)"
+                )
 
         if env_vars.get("HTTPPROXY", "").lower() in ("on", "true", "1"):
             if not env_vars.get("HTTPPROXY_USER"):
@@ -327,6 +343,14 @@ class Profile(BaseModel):
 
         env_vars = _load_env_file(str(self._resolve_env_path()))
         self._provider = env_vars.get("VPN_SERVICE_PROVIDER")
+
+    def _load_vpn_type_from_env(self) -> None:
+        """Load VPN type information from the environment file."""
+
+        from proxy2vpn.adapters.docker_ops import _load_env_file
+
+        env_vars = _load_env_file(str(self._resolve_env_path()))
+        self._vpn_type = env_vars.get("VPN_TYPE", "openvpn")
 
     @classmethod
     def from_anchor(cls, name: str, data: dict) -> "Profile":

--- a/tests/test_profile_create_provider_validation.py
+++ b/tests/test_profile_create_provider_validation.py
@@ -51,12 +51,13 @@ def test_profile_create_accepts_supported_provider(tmp_path, monkeypatch):
         result = runner.invoke(
             app,
             ["--compose-file", str(compose_path), "profile", "create", "test"],
-            input="prov\nuser\npass\nn\nn\n",
+            input="prov\n\nuser\npass\nn\nn\n",
         )
         assert result.exit_code == 0
         env_file = pathlib.Path("profiles/test.env")
         assert env_file.exists()
         content = env_file.read_text()
+        assert "VPN_TYPE=openvpn" in content
         assert "VPN_SERVICE_PROVIDER=prov" in content
         assert "OPENVPN_USER=user" in content
         assert "OPENVPN_PASSWORD=pass" in content

--- a/tests/test_profile_validation.py
+++ b/tests/test_profile_validation.py
@@ -173,3 +173,29 @@ def test_profile_create_fails_with_nonexistent_env_file(tmp_path):
     with _cli_ctx(compose_path) as ctx:
         with pytest.raises(Exit):
             profile_add(ctx, "test-profile", env_file)
+
+
+def test_profile_create_wireguard_without_openvpn_credentials(tmp_path):
+    """Profile with VPN_TYPE=wireguard should not require OPENVPN credentials."""
+    compose_path = _create_test_compose(tmp_path)
+
+    env_file = tmp_path / "wireguard.env"
+    env_file.write_text("VPN_SERVICE_PROVIDER=expressvpn\nVPN_TYPE=wireguard\n")
+
+    with _cli_ctx(compose_path) as ctx:
+        try:
+            profile_add(ctx, "wireguard-profile", env_file)
+        except Exit:
+            pytest.fail("Wireguard profile should not require OPENVPN credentials")
+
+
+def test_profile_create_fails_with_invalid_vpn_type(tmp_path):
+    """Invalid VPN_TYPE values should fail validation."""
+    compose_path = _create_test_compose(tmp_path)
+
+    env_file = tmp_path / "badtype.env"
+    env_file.write_text("VPN_SERVICE_PROVIDER=expressvpn\nVPN_TYPE=bad\n")
+
+    with _cli_ctx(compose_path) as ctx:
+        with pytest.raises(Exit):
+            profile_add(ctx, "bad-profile", env_file)


### PR DESCRIPTION
## Summary
- allow profiles to specify VPN_TYPE as openvpn or wireguard, defaulting to openvpn
- skip OpenVPN credential requirements when using wireguard
- document VPN_TYPE usage and add tests
- fix example profile indentation in validation error output

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adef9c0af8832f9ff71d4fa02139de