### PR TITLE
feat: add interactive vpn creation

### DIFF
--- a/news/157.bugfix.md
+++ b/news/157.bugfix.md
@@ -1,0 +1,1 @@
+incorrect `tunnel-restart` on older gluetun versions

--- a/news/159.bugfix.md
+++ b/news/159.bugfix.md
@@ -1,0 +1,4 @@
+Fix misleading "Missing required arguments" message
+
+- The CLI no longer misreports unrelated runtime errors as "Missing required arguments".
+- This prevents masking real errors (e.g., network or auth issues) when running commands like `vpn public-ip` with a SERVICE argument.

--- a/news/160.bugfix.md
+++ b/news/160.bugfix.md
@@ -1,0 +1,4 @@
+Handle 'public_ip' key from Gluetun control API for `vpn public-ip`
+
+- Fix ValidationError when the control server returns `{ "public_ip": "..." }` instead of `{ "ip": "..." }`.
+- The client now accepts both keys and normalizes to `ip` internally.

--- a/news/161.bugfix.md
+++ b/news/161.bugfix.md
@@ -1,0 +1,4 @@
+Handle 'outcome' key for OpenVPN status responses
+
+- Fix ValidationError when the control server returns `{ "outcome": "running" }` instead of `{ "status": "running" }` for OpenVPN status.
+- The client now accepts both keys and normalizes to `status` internally.

--- a/news/162.feature.md
+++ b/news/162.feature.md
@@ -1,0 +1,3 @@
+Interactive VPN service creation replaces argument-based `vpn create` command.
+
+- `proxy2vpn vpn create` now prompts for service name, profile and ports interactively.

--- a/src/proxy2vpn/adapters/http_client.py
+++ b/src/proxy2vpn/adapters/http_client.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 from urllib.parse import urlparse
 
 import aiohttp
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, AliasChoices
 
 from proxy2vpn.core.config import (
     CONTROL_API_ENDPOINTS,
@@ -201,16 +201,22 @@ class OpenVPNResponse(BaseModel):
 
 
 class IPResponse(BaseModel):
-    """Response payload for the ``/ip`` endpoint."""
+    """Response payload for the ``/ip`` endpoint.
 
-    ip: str
+    Accepts either 'ip' or 'public_ip' keys from server responses.
+    """
+
+    ip: str = Field(validation_alias=AliasChoices("ip", "public_ip"))
     model_config = ConfigDict(extra="ignore")
 
 
 class OpenVPNStatusResponse(BaseModel):
-    """Response payload for the ``/openvpn/status`` endpoint."""
+    """Response payload for the ``/openvpn/status`` endpoint.
 
-    status: str
+    Accepts either 'status' or legacy 'outcome' key from server responses.
+    """
+
+    status: str = Field(validation_alias=AliasChoices("status", "outcome"))
     model_config = ConfigDict(extra="ignore")
 
 
@@ -278,9 +284,28 @@ class GluetunControlClient(HTTPClient):
         return IPResponse(**data)
 
     async def restart_tunnel(self) -> OpenVPNStatusResponse:
-        payload = {"status": "restarted"}
-        data = await self.request("PUT", self.ENDPOINTS["openvpn_status"], json=payload)
-        return OpenVPNStatusResponse(**data)
+        """Request a VPN tunnel restart.
+
+        Tries the newer Gluetun convention first (PUT status="restarted").
+        If the server responds with an error (e.g., older versions not supporting
+        "restarted"), falls back to a stop/start sequence using the same endpoint
+        with status="stopped" then status="running".
+        """
+        try:
+            payload = {"status": "restarted"}
+            data = await self.request(
+                "PUT", self.ENDPOINTS["openvpn_status"], json=payload
+            )
+            return OpenVPNStatusResponse(**data)
+        except HTTPClientError:
+            # Fallback for older servers: stop then start
+            await self.request(
+                "PUT", self.ENDPOINTS["openvpn_status"], json={"status": "stopped"}
+            )
+            data = await self.request(
+                "PUT", self.ENDPOINTS["openvpn_status"], json={"status": "running"}
+            )
+            return OpenVPNStatusResponse(**data)
 
     async def dns_status(self) -> DNSStatusResponse:
         data = await self.get(self.ENDPOINTS["dns_status"])

--- a/src/proxy2vpn/cli/commands/vpn.py
+++ b/src/proxy2vpn/cli/commands/vpn.py
@@ -81,28 +81,21 @@ def _validate_service_locations(services: list[VPNService], force: bool) -> None
 
 
 @app.command("create")
-def create(
-    ctx: typer.Context,
-    name: str = typer.Argument(..., callback=sanitize_name),
-    profile: str = typer.Argument(..., callback=sanitize_name),
-    port: int = typer.Option(
-        0,
-        callback=validate_port,
-        help="Host port to expose; 0 for auto",
-    ),
-    control_port: int = typer.Option(
-        0,
-        callback=validate_port,
-        help="Control port; 0 for auto",
-    ),
-    location: str = typer.Option("", help="Optional location, e.g. city"),
-    force: bool = typer.Option(
-        False, "--force", "-f", help="Ignore location validation"
-    ),
-):
-    """Create a VPN service entry in the compose file."""
+def create(ctx: typer.Context) -> None:
+    """Interactively create a VPN service entry in the compose file."""
 
     manager = ComposeManager.from_ctx(ctx)
+
+    try:
+        name = sanitize_name(typer.prompt("Service name"))
+    except typer.BadParameter as exc:
+        abort(str(exc))
+
+    try:
+        profile = sanitize_name(typer.prompt("Profile name"))
+    except typer.BadParameter as exc:
+        abort(str(exc))
+
     try:
         prof = manager.get_profile(profile)
         provider = prof.provider
@@ -113,6 +106,24 @@ def create(
         )
     except ValueError as exc:
         abort(str(exc))
+
+    port = typer.prompt("Host port to expose (0 for auto)", default=0, type=int)
+    try:
+        port = validate_port(port)
+    except typer.BadParameter as exc:
+        abort(str(exc))
+
+    control_port = typer.prompt("Control port (0 for auto)", default=0, type=int)
+    try:
+        control_port = validate_port(control_port)
+    except typer.BadParameter as exc:
+        abort(str(exc))
+
+    location = typer.prompt("Location (optional)", default="").strip()
+    force = False
+    if location:
+        force = typer.confirm("Ignore location validation?", default=False)
+
     if port == 0:
         port = manager.next_available_port(config.DEFAULT_PORT_START)
     if control_port == 0:
@@ -121,7 +132,6 @@ def create(
         )
 
     env = {"VPN_SERVICE_PROVIDER": provider}
-    location = location.strip()
     if location:
         # Import via adapters module so tests can monkeypatch ServerManager
         from proxy2vpn.adapters import server_manager
@@ -137,6 +147,7 @@ def create(
             env["SERVER_CITIES"] = city
         if country:
             env["SERVER_COUNTRIES"] = country
+
     labels = {
         "vpn.type": "vpn",
         "vpn.port": str(port),

--- a/src/proxy2vpn/cli/commands/vpn.py
+++ b/src/proxy2vpn/cli/commands/vpn.py
@@ -40,6 +40,32 @@ def _service_control_base_url(ctx: typer.Context, name: str) -> str:
     return f"http://localhost:{svc.control_port}/v1"
 
 
+def _resolve_service_name(ctx: typer.Context, service: str | None) -> str:
+    """Resolve optional service name.
+
+    - If provided, return it.
+    - If not provided, auto-select when there is exactly one service.
+    - If none or multiple exist, abort with a helpful message.
+    """
+    if service:
+        return service
+    manager = ComposeManager.from_ctx(ctx)
+    services = manager.list_services()
+    if not services:
+        abort(
+            "No VPN services found.",
+            "Create one with 'proxy2vpn vpn create <name> <profile>'.",
+        )
+    if len(services) == 1:
+        return services[0].name
+    names = ", ".join(sorted(s.name for s in services))
+    abort(
+        "Multiple VPN services found; please specify SERVICE.",
+        f"Available: {names}",
+    )
+    return ""  # unreachable, for typing
+
+
 def _validate_service_locations(services: list[VPNService], force: bool) -> None:
     if force:
         return
@@ -615,11 +641,14 @@ async def export_proxies(
 @run_async
 async def status(
     ctx: typer.Context,
-    service: str = typer.Argument(..., callback=sanitize_name),
+    service: str | None = typer.Argument(
+        None, callback=lambda v: sanitize_name(v) if v else None
+    ),
 ):
     """Show control server status for SERVICE."""
 
-    base_url = _service_control_base_url(ctx, service)
+    resolved = _resolve_service_name(ctx, service)
+    base_url = _service_control_base_url(ctx, resolved)
     # Import via adapters module so tests can monkeypatch the client
     from proxy2vpn.adapters import http_client
 
@@ -642,11 +671,14 @@ async def status(
 @run_async
 async def public_ip(
     ctx: typer.Context,
-    service: str = typer.Argument(..., callback=sanitize_name),
+    service: str | None = typer.Argument(
+        None, callback=lambda v: sanitize_name(v) if v else None
+    ),
 ):
     """Show public IP reported by the control API for SERVICE."""
 
-    base_url = _service_control_base_url(ctx, service)
+    resolved = _resolve_service_name(ctx, service)
+    base_url = _service_control_base_url(ctx, resolved)
     # Import via adapters module so tests can monkeypatch the client
     from proxy2vpn.adapters import http_client
 
@@ -659,11 +691,14 @@ async def public_ip(
 @run_async
 async def dns_status(
     ctx: typer.Context,
-    service: str = typer.Argument(..., callback=sanitize_name),
+    service: str | None = typer.Argument(
+        None, callback=lambda v: sanitize_name(v) if v else None
+    ),
 ):
     """Show DNS service status for SERVICE."""
 
-    base_url = _service_control_base_url(ctx, service)
+    resolved = _resolve_service_name(ctx, service)
+    base_url = _service_control_base_url(ctx, resolved)
     from proxy2vpn.adapters import http_client
 
     async with http_client.GluetunControlClient(base_url) as client:
@@ -675,11 +710,14 @@ async def dns_status(
 @run_async
 async def updater_status(
     ctx: typer.Context,
-    service: str = typer.Argument(..., callback=sanitize_name),
+    service: str | None = typer.Argument(
+        None, callback=lambda v: sanitize_name(v) if v else None
+    ),
 ):
     """Show updater job status for SERVICE."""
 
-    base_url = _service_control_base_url(ctx, service)
+    resolved = _resolve_service_name(ctx, service)
+    base_url = _service_control_base_url(ctx, resolved)
     from proxy2vpn.adapters import http_client
 
     async with http_client.GluetunControlClient(base_url) as client:
@@ -691,11 +729,14 @@ async def updater_status(
 @run_async
 async def port_forwarded(
     ctx: typer.Context,
-    service: str = typer.Argument(..., callback=sanitize_name),
+    service: str | None = typer.Argument(
+        None, callback=lambda v: sanitize_name(v) if v else None
+    ),
 ):
     """Show port forwarded for SERVICE."""
 
-    base_url = _service_control_base_url(ctx, service)
+    resolved = _resolve_service_name(ctx, service)
+    base_url = _service_control_base_url(ctx, resolved)
     from proxy2vpn.adapters import http_client
 
     async with http_client.GluetunControlClient(base_url) as client:
@@ -707,11 +748,14 @@ async def port_forwarded(
 @run_async
 async def restart_tunnel(
     ctx: typer.Context,
-    service: str = typer.Argument(..., callback=sanitize_name),
+    service: str | None = typer.Argument(
+        None, callback=lambda v: sanitize_name(v) if v else None
+    ),
 ):
     """Restart the VPN tunnel for SERVICE via the control API."""
 
-    base_url = _service_control_base_url(ctx, service)
+    resolved = _resolve_service_name(ctx, service)
+    base_url = _service_control_base_url(ctx, resolved)
     # Import via adapters module so tests can monkeypatch the client
     from proxy2vpn.adapters import http_client
 

--- a/src/proxy2vpn/cli/typer_ext.py
+++ b/src/proxy2vpn/cli/typer_ext.py
@@ -56,7 +56,7 @@ class HelpfulTyper(typer.Typer):
         except FileNotFoundError as exc:
             self.console.print(f"[red]Error:[/red] {exc}")
             raise SystemExit(1)
-        except Exception as exc:
+        except Exception:
             # For unexpected runtime errors, do not mis-report them as missing arguments.
             # Let Typer/Click propagate the original exception so users see the real cause.
             raise

--- a/src/proxy2vpn/cli/typer_ext.py
+++ b/src/proxy2vpn/cli/typer_ext.py
@@ -57,13 +57,8 @@ class HelpfulTyper(typer.Typer):
             self.console.print(f"[red]Error:[/red] {exc}")
             raise SystemExit(1)
         except Exception as exc:
-            # Handle other exceptions more gracefully
-            if "Missing argument" in str(exc) or "required" in str(exc).lower():
-                self.console.print("\n[red]Error:[/red] Missing required arguments")
-                self.console.print(
-                    "[dim]Run the command with '--help' to see required arguments.[/dim]"
-                )
-                raise SystemExit(2)
+            # For unexpected runtime errors, do not mis-report them as missing arguments.
+            # Let Typer/Click propagate the original exception so users see the real cause.
             raise
 
     def _handle_usage_error(self, exc: UsageError) -> None:

--- a/tests/test_cli_location_validation.py
+++ b/tests/test_cli_location_validation.py
@@ -36,18 +36,8 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
 
     result = runner.invoke(
         app,
-        [
-            "--compose-file",
-            str(compose_path),
-            "vpn",
-            "create",
-            "vpn3",
-            "test",
-            "--port",
-            "7777",
-            "--location",
-            "Toronto,CA",
-        ],
+        ["--compose-file", str(compose_path), "vpn", "create"],
+        input="vpn3\ntest\n7777\n0\nToronto,CA\n\n",
     )
     assert result.exit_code == 0
 
@@ -67,36 +57,15 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
 
     result = runner.invoke(
         app,
-        [
-            "--compose-file",
-            str(compose_path),
-            "vpn",
-            "create",
-            "vpn4",
-            "test",
-            "--port",
-            "7778",
-            "--location",
-            "Atlantis",
-        ],
+        ["--compose-file", str(compose_path), "vpn", "create"],
+        input="vpn4\ntest\n7778\n0\nAtlantis\nn\n",
     )
     assert result.exit_code != 0
 
     result = runner.invoke(
         app,
-        [
-            "--compose-file",
-            str(compose_path),
-            "vpn",
-            "create",
-            "vpn4",
-            "test",
-            "--port",
-            "7778",
-            "--location",
-            "Atlantis",
-            "--force",
-        ],
+        ["--compose-file", str(compose_path), "vpn", "create"],
+        input="vpn4\ntest\n7778\n0\nAtlantis\ny\n",
     )
     assert result.exit_code == 0
 

--- a/tests/test_vpn_create_interactive.py
+++ b/tests/test_vpn_create_interactive.py
@@ -1,0 +1,34 @@
+import pathlib
+
+from typer.testing import CliRunner
+
+from proxy2vpn.cli.main import app
+from proxy2vpn.adapters.compose_manager import ComposeManager
+from proxy2vpn.core.models import Profile
+
+
+def _create_compose(tmp_path: pathlib.Path) -> pathlib.Path:
+    compose_path = tmp_path / "compose.yml"
+    ComposeManager.create_initial_compose(compose_path, force=True)
+    return compose_path
+
+
+def test_vpn_create_interactive(tmp_path):
+    compose_path = _create_compose(tmp_path)
+    env_file = tmp_path / "env.test"
+    env_file.write_text("VPN_SERVICE_PROVIDER=prov\n")
+    manager = ComposeManager(compose_path)
+    manager.add_profile(Profile(name="test", env_file=str(env_file)))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--compose-file", str(compose_path), "vpn", "create"],
+        input="svc\ntest\n0\n0\n\n",
+    )
+    assert result.exit_code == 0
+    manager = ComposeManager(compose_path)
+    svc = manager.get_service("svc")
+    assert svc.profile == "test"
+    assert svc.port == 20000
+    assert svc.control_port == 30000


### PR DESCRIPTION
## Summary
- replace argument-based `vpn create` with interactive prompts
- cover interactive vpn creation and location validation with tests
- drop unused variable in CLI helper

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adfafcd46c832fabeb6f01ef1456d2