### PR TITLE
feat: interactive profile selection for vpn creation

### DIFF
--- a/news/163.feature.md
+++ b/news/163.feature.md
@@ -1,0 +1,1 @@
+Add interactive profile selection when creating VPN services with `vpn create`.

--- a/src/proxy2vpn/cli/commands/vpn.py
+++ b/src/proxy2vpn/cli/commands/vpn.py
@@ -91,21 +91,42 @@ def create(ctx: typer.Context) -> None:
     except typer.BadParameter as exc:
         abort(str(exc))
 
-    try:
-        profile = sanitize_name(typer.prompt("Profile name"))
-    except typer.BadParameter as exc:
-        abort(str(exc))
-
-    try:
-        prof = manager.get_profile(profile)
-        provider = prof.provider
-    except KeyError:
+    profiles = manager.list_profiles()
+    if not profiles:
         abort(
-            f"Profile '{profile}' not found",
-            "Create it with 'proxy2vpn profile create'",
+            "No profiles found.",
+            "Create one with 'proxy2vpn profile create'",
         )
-    except ValueError as exc:
-        abort(str(exc))
+
+    console.print("Available profiles:")
+    for idx, p in enumerate(profiles, start=1):
+        console.print(f"{idx}. {p.name}")
+
+    selected = typer.prompt("Select profile", default="1").strip()
+
+    if selected.isdigit():
+        idx = int(selected)
+        if not 1 <= idx <= len(profiles):
+            abort(
+                f"Invalid selection {selected}",
+                f"Select a number between 1 and {len(profiles)}",
+            )
+        prof = profiles[idx - 1]
+    else:
+        try:
+            selected = sanitize_name(selected)
+        except typer.BadParameter as exc:
+            abort(str(exc))
+        prof_map = {p.name: p for p in profiles}
+        if selected not in prof_map:
+            abort(
+                f"Profile '{selected}' not found",
+                "Create one with 'proxy2vpn profile create'",
+            )
+        prof = prof_map[selected]
+
+    profile = prof.name
+    provider = prof.provider
 
     port = typer.prompt("Host port to expose (0 for auto)", default=0, type=int)
     try:

--- a/tests/test_cli_location_validation.py
+++ b/tests/test_cli_location_validation.py
@@ -37,7 +37,7 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
     result = runner.invoke(
         app,
         ["--compose-file", str(compose_path), "vpn", "create"],
-        input="vpn3\ntest\n7777\n0\nToronto,CA\n\n",
+        input="vpn3\n1\n7777\n0\nToronto,CA\n\n",
     )
     assert result.exit_code == 0
 
@@ -58,14 +58,14 @@ def test_vpn_create_location_validation(tmp_path, monkeypatch):
     result = runner.invoke(
         app,
         ["--compose-file", str(compose_path), "vpn", "create"],
-        input="vpn4\ntest\n7778\n0\nAtlantis\nn\n",
+        input="vpn4\n1\n7778\n0\nAtlantis\nn\n",
     )
     assert result.exit_code != 0
 
     result = runner.invoke(
         app,
         ["--compose-file", str(compose_path), "vpn", "create"],
-        input="vpn4\ntest\n7778\n0\nAtlantis\ny\n",
+        input="vpn4\n1\n7778\n0\nAtlantis\ny\n",
     )
     assert result.exit_code == 0
 

--- a/tests/test_vpn_create_interactive.py
+++ b/tests/test_vpn_create_interactive.py
@@ -27,6 +27,7 @@ def test_vpn_create_interactive(tmp_path):
         input="svc\ntest\n0\n0\n\n",
     )
     assert result.exit_code == 0
+    assert "Available profiles" in result.stdout
     manager = ComposeManager(compose_path)
     svc = manager.get_service("svc")
     assert svc.profile == "test"


### PR DESCRIPTION
## Summary
- list available profiles during `vpn create`
- allow selecting profile by number or name
- cover interactive selection in tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68adfefce114832fb59d4f4df09e1f43